### PR TITLE
feat: replicate event bus kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ pip-log.txt
 .tox
 coverage.xml
 htmlcov/
-
+/pii_report/
 
 
 # The Silver Searcher

--- a/edx_event_bus_redis/__init__.py
+++ b/edx_event_bus_redis/__init__.py
@@ -2,6 +2,8 @@
 Redis Streams implementation for the Open edX event bus.
 """
 
+from edx_event_bus_redis.internal.producer import create_producer
+
 __version__ = '0.1.0'
 
 default_app_config = 'edx_event_bus_redis.apps.EdxEventBusRedisConfig'  # pylint: disable=invalid-name

--- a/edx_event_bus_redis/internal/__init__.py
+++ b/edx_event_bus_redis/internal/__init__.py
@@ -1,0 +1,7 @@
+"""
+Most of the implementation of the package is here and is internal-only.
+
+Public API will be in the ``edx_event_bus_kafka`` module for the most part.
+
+See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reasoning.
+"""

--- a/edx_event_bus_redis/internal/__init__.py
+++ b/edx_event_bus_redis/internal/__init__.py
@@ -1,7 +1,7 @@
 """
 Most of the implementation of the package is here and is internal-only.
 
-Public API will be in the ``edx_event_bus_kafka`` module for the most part.
+Public API will be in the ``edx_event_bus_redis`` module for the most part.
 
 See ADR ``docs/decisions/0006-public-api-and-app-organization.rst`` for the reasoning.
 """

--- a/edx_event_bus_redis/internal/config.py
+++ b/edx_event_bus_redis/internal/config.py
@@ -1,0 +1,137 @@
+"""
+Configuration loading and validation.
+
+This module is for internal use only.
+"""
+
+import warnings
+from functools import lru_cache
+from typing import Optional
+
+from django.conf import settings
+from django.dispatch import receiver
+from django.test.signals import setting_changed
+
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+try:
+    import confluent_kafka
+    from confluent_kafka.schema_registry import SchemaRegistryClient
+except ImportError:  # pragma: no cover
+    confluent_kafka = None
+
+
+# return type (Optional[SchemaRegistryClient]) removed from signature to avoid error on import
+@lru_cache  # will just be one cache entry, in practice
+def get_schema_registry_client():
+    """
+    Create a schema registry client from common settings.
+
+    This is cached on the assumption of a performance benefit (avoid reloading settings and
+    reconstructing client) but it may also be that the client keeps around long-lived
+    connections that we could benefit from.
+
+    Returns
+        None if confluent_kafka library is not available or the settings are invalid.
+        SchemaRegistryClient if it is.
+    """
+    if not confluent_kafka:  # pragma: no cover
+        warnings.warn('Library confluent-kafka not available. Cannot create schema registry client.')
+        return None
+
+    # .. setting_name: EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL
+    # .. setting_default: None
+    # .. setting_description: URL of the Avro schema registry, required for managing the evolution
+    #   of event bus data and ensuring that consumers are able to decode the events that
+    #   are produced. This URL is required for both producers and consumers and must point
+    #   to an instance of Confluent Schema Registry:
+    #   https://docs.confluent.io/platform/current/schema-registry/index.html
+    #   If needed, auth information must be added to ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY``
+    #   and ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET``.
+    url = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL', None)
+    if url is None:
+        warnings.warn("Cannot configure event-bus-kafka: Missing setting EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL")
+        return None
+
+    # .. setting_name: EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY
+    # .. setting_default: ''
+    # .. setting_description: API key for talking to the Avro schema registry specified in
+    #   ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL``. Optional.
+    key = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY', '')
+    # .. setting_name: EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET
+    # .. setting_default: ''
+    # .. setting_description: API secret for talking to the Avro schema registry specified in
+    #   ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL``. Optional.
+    secret = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET', '')
+
+    return SchemaRegistryClient({
+        'url': url,
+        'basic.auth.user.info': f"{key}:{secret}",
+    })
+
+
+def load_common_settings() -> Optional[dict]:
+    """
+    Load common settings, a base for either producer or consumer configuration.
+
+    Warns and returns None if essential settings are missing.
+    """
+    # .. setting_name: EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS
+    # .. setting_default: None
+    # .. setting_description: List of one or more Kafka bootstrap servers, a comma-separated
+    #   list of hosts and optional ports, and is required for both producers and consumers.
+    #   See https://kafka.apache.org/documentation/ for more info.
+    bootstrap_servers = getattr(settings, 'EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS', None)
+    if bootstrap_servers is None:
+        warnings.warn("Cannot configure event-bus-kafka: Missing setting EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS")
+        return None
+
+    base_settings = {
+        'bootstrap.servers': bootstrap_servers,
+    }
+
+    # .. setting_name: EVENT_BUS_KAFKA_API_KEY
+    # .. setting_default: None
+    # .. setting_description: Optional API key for connecting to the Kafka cluster
+    #   via SASL/PLAIN over TLS. Used as the SASL username. If not specified, no
+    #   authentication will be attempted.
+    key = getattr(settings, 'EVENT_BUS_KAFKA_API_KEY', None)
+    # .. setting_name: EVENT_BUS_KAFKA_API_SECRET
+    # .. setting_default: None
+    # .. setting_description: Optional API secret for connecting to the Kafka cluster
+    #   via SASL/PLAIN over TLS. Used as the SASL password. If not specified, no
+    #   authentication will be attempted.
+    secret = getattr(settings, 'EVENT_BUS_KAFKA_API_SECRET', None)
+
+    if key and secret:
+        base_settings.update({
+            'sasl.mechanism': 'PLAIN',
+            'security.protocol': 'SASL_SSL',
+            'sasl.username': key,
+            'sasl.password': secret,
+        })
+
+    return base_settings
+
+
+def get_full_topic(base_topic: str) -> str:
+    """
+    Given a base topic name, add a prefix (if configured).
+    """
+    # .. setting_name: EVENT_BUS_TOPIC_PREFIX
+    # .. setting_default: None
+    # .. setting_description: If provided, add this as a prefix to any topic names (delimited by a hyphen)
+    #   when either producing or consuming events. This can be used to support separation of environments,
+    #   e.g. if multiple staging or test environments are sharing a cluster. For example, if the base topic
+    #   name is "user-logins", then if EVENT_BUS_TOPIC_PREFIX=stage, the producer and consumer would instead
+    #   work with the topic "stage-user-logins".
+    topic_prefix = getattr(settings, 'EVENT_BUS_TOPIC_PREFIX', None)
+    if topic_prefix:
+        return f"{topic_prefix}-{base_topic}"
+    else:
+        return base_topic
+
+
+@receiver(setting_changed)
+def _reset_state(sender, **kwargs):  # pylint: disable=unused-argument
+    """Reset caches when settings change during unit tests."""
+    get_schema_registry_client.cache_clear()

--- a/edx_event_bus_redis/internal/config.py
+++ b/edx_event_bus_redis/internal/config.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from django.conf import settings
 
+
 def load_common_settings() -> Optional[dict]:
     """
     Load common settings, a base for either producer or consumer configuration.
@@ -25,7 +26,6 @@ def load_common_settings() -> Optional[dict]:
     if url is None:
         warnings.warn("Cannot configure event-bus-redis: Missing setting EVENT_BUS_REDIS_CONNECTION_URL")
         return None
-
 
     base_settings = {
         'url': url,

--- a/edx_event_bus_redis/internal/config.py
+++ b/edx_event_bus_redis/internal/config.py
@@ -5,69 +5,9 @@ This module is for internal use only.
 """
 
 import warnings
-from functools import lru_cache
 from typing import Optional
 
 from django.conf import settings
-from django.dispatch import receiver
-from django.test.signals import setting_changed
-
-# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
-try:
-    import confluent_kafka
-    from confluent_kafka.schema_registry import SchemaRegistryClient
-except ImportError:  # pragma: no cover
-    confluent_kafka = None
-
-
-# return type (Optional[SchemaRegistryClient]) removed from signature to avoid error on import
-@lru_cache  # will just be one cache entry, in practice
-def get_schema_registry_client():
-    """
-    Create a schema registry client from common settings.
-
-    This is cached on the assumption of a performance benefit (avoid reloading settings and
-    reconstructing client) but it may also be that the client keeps around long-lived
-    connections that we could benefit from.
-
-    Returns
-        None if confluent_kafka library is not available or the settings are invalid.
-        SchemaRegistryClient if it is.
-    """
-    if not confluent_kafka:  # pragma: no cover
-        warnings.warn('Library confluent-kafka not available. Cannot create schema registry client.')
-        return None
-
-    # .. setting_name: EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL
-    # .. setting_default: None
-    # .. setting_description: URL of the Avro schema registry, required for managing the evolution
-    #   of event bus data and ensuring that consumers are able to decode the events that
-    #   are produced. This URL is required for both producers and consumers and must point
-    #   to an instance of Confluent Schema Registry:
-    #   https://docs.confluent.io/platform/current/schema-registry/index.html
-    #   If needed, auth information must be added to ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY``
-    #   and ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET``.
-    url = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL', None)
-    if url is None:
-        warnings.warn("Cannot configure event-bus-kafka: Missing setting EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL")
-        return None
-
-    # .. setting_name: EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY
-    # .. setting_default: ''
-    # .. setting_description: API key for talking to the Avro schema registry specified in
-    #   ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL``. Optional.
-    key = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY', '')
-    # .. setting_name: EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET
-    # .. setting_default: ''
-    # .. setting_description: API secret for talking to the Avro schema registry specified in
-    #   ``EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL``. Optional.
-    secret = getattr(settings, 'EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET', '')
-
-    return SchemaRegistryClient({
-        'url': url,
-        'basic.auth.user.info': f"{key}:{secret}",
-    })
-
 
 def load_common_settings() -> Optional[dict]:
     """
@@ -75,41 +15,21 @@ def load_common_settings() -> Optional[dict]:
 
     Warns and returns None if essential settings are missing.
     """
-    # .. setting_name: EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS
+    # .. setting_name: EVENT_BUS_REDIS_CONNECTION_URL
     # .. setting_default: None
-    # .. setting_description: List of one or more Kafka bootstrap servers, a comma-separated
-    #   list of hosts and optional ports, and is required for both producers and consumers.
-    #   See https://kafka.apache.org/documentation/ for more info.
-    bootstrap_servers = getattr(settings, 'EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS', None)
-    if bootstrap_servers is None:
-        warnings.warn("Cannot configure event-bus-kafka: Missing setting EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS")
+    # .. setting_description: Redis connection url.
+    #   For example::
+    #       redis://[[username]:[password]]@localhost:6379/0
+    #       rediss://[[username]:[password]]@localhost:6379/0
+    url = getattr(settings, 'EVENT_BUS_REDIS_CONNECTION_URL', None)
+    if url is None:
+        warnings.warn("Cannot configure event-bus-redis: Missing setting EVENT_BUS_REDIS_CONNECTION_URL")
         return None
 
+
     base_settings = {
-        'bootstrap.servers': bootstrap_servers,
+        'url': url,
     }
-
-    # .. setting_name: EVENT_BUS_KAFKA_API_KEY
-    # .. setting_default: None
-    # .. setting_description: Optional API key for connecting to the Kafka cluster
-    #   via SASL/PLAIN over TLS. Used as the SASL username. If not specified, no
-    #   authentication will be attempted.
-    key = getattr(settings, 'EVENT_BUS_KAFKA_API_KEY', None)
-    # .. setting_name: EVENT_BUS_KAFKA_API_SECRET
-    # .. setting_default: None
-    # .. setting_description: Optional API secret for connecting to the Kafka cluster
-    #   via SASL/PLAIN over TLS. Used as the SASL password. If not specified, no
-    #   authentication will be attempted.
-    secret = getattr(settings, 'EVENT_BUS_KAFKA_API_SECRET', None)
-
-    if key and secret:
-        base_settings.update({
-            'sasl.mechanism': 'PLAIN',
-            'security.protocol': 'SASL_SSL',
-            'sasl.username': key,
-            'sasl.password': secret,
-        })
-
     return base_settings
 
 
@@ -129,9 +49,3 @@ def get_full_topic(base_topic: str) -> str:
         return f"{topic_prefix}-{base_topic}"
     else:
         return base_topic
-
-
-@receiver(setting_changed)
-def _reset_state(sender, **kwargs):  # pylint: disable=unused-argument
-    """Reset caches when settings change during unit tests."""
-    get_schema_registry_client.cache_clear()

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -111,7 +111,6 @@ class RedisEventConsumer:
         Create a DeserializingConsumer for events of the given signal instance.
 
         Returns
-            None if confluent_kafka is not available.
             DeserializingConsumer if it is.
         """
 
@@ -124,7 +123,7 @@ class RedisEventConsumer:
             'value.deserializer': None,
             # Turn off auto commit. Auto commit will commit offsets for the entire batch of messages received,
             # potentially resulting in data loss if some of those messages are not fully processed. See
-            # https://newrelic.com/blog/best-practices/kafka-consumer-config-auto-commit-data-loss
+            # https://newrelic.com/blog/best-practices/redis-consumer-config-auto-commit-data-loss
             'enable.auto.commit': False,
         })
 

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -129,7 +129,7 @@ class RedisEventConsumer:
         })
 
         # create redis client and consumer.
-        return None
+        return consumer_config
 
     def _shut_down(self):
         """
@@ -186,7 +186,9 @@ class RedisEventConsumer:
 
                 # Detect probably-broken consumer and exit with error.
                 if CONSECUTIVE_ERRORS_LIMIT and consecutive_errors >= CONSECUTIVE_ERRORS_LIMIT:
-                    raise Exception(f"Too many consecutive errors, exiting ({consecutive_errors} in a row)")
+                    raise Exception(  # pylint: disable=broad-exception-raised
+                        f"Too many consecutive errors, exiting ({consecutive_errors} in a row)"
+                    )
 
                 msg = None
                 try:
@@ -206,7 +208,7 @@ class RedisEventConsumer:
                     # Kill the infinite loop if the error is fatal for the consumer
                     _, redis_error = self._get_redis_message_and_error(message=msg, error=e)
                     # https://redis.readthedocs.io/en/stable/exceptions.html#redis.exceptions.TryAgainError
-                    if redis_error: # and redis_error.fatal()
+                    if redis_error:  # and redis_error.fatal()
                         raise e
                     # Prevent fast error-looping when no event received from broker. Because
                     # DeserializingConsumer raises rather than returning a Message when it has an
@@ -386,7 +388,7 @@ class RedisEventConsumer:
         try:
             # This is gross, but our record_exception wrapper doesn't take args at the moment,
             # and will only read the exception from stack context.
-            raise Exception(error)
+            raise Exception(error)  # pylint: disable=broad-exception-raised
         except BaseException:
             self._add_message_monitoring(run_context=run_context, message=maybe_redis_message, error=error)
             record_exception()

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -1,0 +1,645 @@
+"""
+Core consumer and event-loop code.
+"""
+import logging
+import time
+import warnings
+from datetime import datetime
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+from edx_django_utils.monitoring import record_exception, set_custom_attribute
+from edx_toggles.toggles import SettingToggle
+from openedx_events.event_bus.avro.deserializer import AvroSignalDeserializer
+from openedx_events.tooling import OpenEdxPublicSignal
+
+from .config import get_full_topic, get_schema_registry_client, load_common_settings
+from .utils import (
+    AUDIT_LOGGING_ENABLED,
+    HEADER_EVENT_TYPE,
+    HEADER_ID,
+    _get_metadata_from_headers,
+    get_message_header_values,
+    last_message_header_value,
+)
+
+logger = logging.getLogger(__name__)
+
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+try:
+    import confluent_kafka
+    from confluent_kafka import TIMESTAMP_NOT_AVAILABLE, DeserializingConsumer
+    from confluent_kafka.error import KafkaError
+    from confluent_kafka.schema_registry.avro import AvroDeserializer
+except ImportError:  # pragma: no cover
+    confluent_kafka = None
+
+# .. toggle_name: EVENT_BUS_KAFKA_CONSUMERS_ENABLED
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: True
+# .. toggle_description: If set to False, consumer will exit immediately. This can be used as an emergency kill-switch
+#   to disable a consumer—as long as the management command is killed and restarted when settings change.
+# .. toggle_use_cases: opt_out
+# .. toggle_creation_date: 2022-01-31
+KAFKA_CONSUMERS_ENABLED = SettingToggle('EVENT_BUS_KAFKA_CONSUMERS_ENABLED', default=True)
+
+# .. setting_name: EVENT_BUS_KAFKA_CONSUMER_POLL_TIMEOUT
+# .. setting_default: 1.0
+# .. setting_description: How long the consumer should wait, in seconds, for the Kafka broker
+#   to respond to a poll() call.
+CONSUMER_POLL_TIMEOUT = getattr(settings, 'EVENT_BUS_KAFKA_CONSUMER_POLL_TIMEOUT', 1.0)
+
+# .. setting_name: EVENT_BUS_KAFKA_CONSUMER_POLL_FAILURE_SLEEP
+# .. setting_default: 1.0
+# .. setting_description: When the consumer fails to retrieve an event from the broker,
+#   it will sleep for this many seconds before trying again. This is to prevent fast error-loops
+#   if the broker is down or the consumer is misconfigured. It *may* also sleep for errors that
+#   involve receiving an unreadable event, but this could change in the future to be more
+#   specific to "no event received from broker".
+POLL_FAILURE_SLEEP = getattr(settings, 'EVENT_BUS_KAFKA_CONSUMER_POLL_FAILURE_SLEEP', 1.0)
+
+
+class UnusableMessageError(Exception):
+    """
+    Indicates that a message was successfully received but could not be processed.
+
+    This could be invalid headers, an unknown signal, or other issue specific to
+    the contents of the message.
+    """
+
+
+class ReceiverError(Exception):
+    """
+    Indicates that one or more receivers of a signal raised an exception when called.
+    """
+
+    def __init__(self, message: str, causes: list):
+        """
+        Create ReceiverError with a message and a list of exceptions returned by receivers.
+        """
+        super().__init__(message)
+        self.causes = causes  # just used for testing
+
+
+def _reconnect_to_db_if_needed():
+    """
+    Reconnects the db connection if needed.
+
+    This is important because Django only does connection validity/age checks as part of
+    its request/response cycle, which isn't in effect for the consume-loop. If we don't
+    force these checks, a broken connection will remain broken indefinitely. For most
+    consumers, this will cause event processing to fail.
+    """
+    has_connection = bool(connection.connection)
+    requires_reconnect = has_connection and not connection.is_usable()
+    if requires_reconnect:
+        connection.connect()
+
+
+class KafkaEventConsumer:
+    """
+    Construct consumer for the given topic, group, and signal. The consumer can then
+    emit events from the event bus using the configured signal.
+
+    Note that the topic should be specified here *without* the optional environment prefix.
+
+    Can also consume messages indefinitely off the queue.
+    """
+
+    def __init__(self, topic, group_id, signal):
+        if confluent_kafka is None:  # pragma: no cover
+            raise Exception('Library confluent-kafka not available. Cannot create event consumer.')
+
+        self.topic = topic
+        self.group_id = group_id
+        self.signal = signal
+        self.consumer = self._create_consumer()
+        self._shut_down_loop = False
+
+    # return type (Optional[DeserializingConsumer]) removed from signature to avoid error on import
+    def _create_consumer(self):
+        """
+        Create a DeserializingConsumer for events of the given signal instance.
+
+        Returns
+            None if confluent_kafka is not available.
+            DeserializingConsumer if it is.
+        """
+
+        schema_registry_client = get_schema_registry_client()
+
+        signal_deserializer = AvroSignalDeserializer(self.signal)
+
+        def inner_from_dict(event_data_dict, ctx=None):  # pylint: disable=unused-argument
+            return signal_deserializer.from_dict(event_data_dict)
+
+        consumer_config = load_common_settings()
+
+        # We do not deserialize the key because we don't need it for anything yet.
+        # Also see https://github.com/openedx/openedx-events/issues/86 for some challenges on determining key schema.
+        consumer_config.update({
+            'group.id': self.group_id,
+            'value.deserializer': AvroDeserializer(schema_str=signal_deserializer.schema_string(),
+                                                   schema_registry_client=schema_registry_client,
+                                                   from_dict=inner_from_dict),
+            # Turn off auto commit. Auto commit will commit offsets for the entire batch of messages received,
+            # potentially resulting in data loss if some of those messages are not fully processed. See
+            # https://newrelic.com/blog/best-practices/kafka-consumer-config-auto-commit-data-loss
+            'enable.auto.commit': False,
+        })
+
+        return DeserializingConsumer(consumer_config)
+
+    def _shut_down(self):
+        """
+        Test utility for shutting down the consumer loop.
+        """
+        self._shut_down_loop = True
+
+    def reset_offsets_and_sleep_indefinitely(self, offset_timestamp):
+        """
+        Reset any assigned partitions to the given offset, and sleep indefinitely.
+
+        Arguments:
+            offset_timestamp (datetime): Reset the offsets of the consumer partitions to this timestamp.
+        """
+
+        def reset_offsets(consumer, partitions):
+            # This is a callback method used on consumer assignment to handle offset reset logic.
+            # We do not want to attempt to change offsets if the offset is None.
+            if offset_timestamp is None:
+                return
+
+            # Get the offset from the epoch. Kafka expects offsets in milliseconds for offsets_for_times. Although
+            # this is undocumented in the libraries we're using (confluent-kafka and librdkafa), for reference
+            # see the docs for kafka-python:
+            # https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html#kafka.KafkaConsumer.offsets_for_times
+            offset_timestamp_ms = int(offset_timestamp.timestamp()*1000)
+            # We set the epoch timestamp in the offset position.
+            for partition in partitions:
+                partition.offset = offset_timestamp_ms
+
+            partitions_with_offsets = consumer.offsets_for_times(partitions, timeout=1.0)
+
+            # Partitions have an error field that may be set on return.
+            errors = [p.error for p in partitions_with_offsets if p.error is not None]
+            if len(errors) > 0:
+                raise Exception("Error getting offsets for timestamps: {errors}")
+
+            logger.info(f'Found offsets for timestamp {offset_timestamp}: {partitions_with_offsets}')
+
+            # We need to commit these offsets to Kafka in order to ensure these offsets are persisted.
+            consumer.commit(offsets=partitions_with_offsets)
+
+        full_topic = get_full_topic(self.topic)
+        # Partition assignment will trigger the reset logic. This should happen on the first poll call,
+        # but will also happen any time the broker needs to rebalance partitions among the consumer
+        # group, which could happen repeatedly over the lifetime of this process.
+        self.consumer.subscribe([full_topic], on_assign=reset_offsets)
+
+        while True:
+            # Allow unit tests to break out of loop
+            if self._shut_down_loop:
+                break
+
+            # This log message may be noisy when we are replaying, but hopefully we only see it
+            # once every 30 seconds.
+            logger.info("Offsets are being reset. Sleeping instead of consuming events.")
+
+            # We are calling poll here because we believe the offsets will not be set
+            # correctly until poll is called, despite the offsets being reset in a different call.
+            # This is because we don't believe that the partitions for the current consumer are assigned
+            # until the first poll happens. Because we are not trying to consume any messages in this mode,
+            # we are deliberately calling poll without processing the message it returns
+            # or commiting the new offset.
+            self.consumer.poll(timeout=CONSUMER_POLL_TIMEOUT)
+
+            time.sleep(30)
+            continue
+
+    def _consume_indefinitely(self):
+        """
+        Consume events from a topic in an infinite loop.
+        """
+
+        # This is already checked at the Command level, but it's possible this loop
+        # could get called some other way, so check it here too.
+        if not KAFKA_CONSUMERS_ENABLED.is_enabled():
+            logger.error("Kafka consumers not enabled, exiting.")
+            return
+
+        # .. setting_name: EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT
+        # .. setting_default: None
+        # .. setting_description: If the consumer encounters this many consecutive errors, exit with an
+        #   error. This is intended to be used in a context where a management system (such as Kubernetes)
+        #   will relaunch the consumer automatically. The effect is that all runtime state is cleared,
+        #   allowing consumers in arbitrary "stuck" states to resume their work automatically. (The impetus
+        #   for this setting was a Django DB connection failure that was staying failed.) Process
+        #   managers like Kubernetes will use delays and backoffs, so this may also help with transient
+        #   issues such as networking problems or a burst of errors in a downstream service. Errors may
+        #   include failure to poll, failure to decode events, or errors returned by signal handlers.
+        #   This does not prevent committing of offsets back to the broker; any messages that caused an
+        #   error will still be marked as consumed, and may need to be replayed.
+        CONSECUTIVE_ERRORS_LIMIT = getattr(settings, 'EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT', None)
+
+        try:
+            full_topic = get_full_topic(self.topic)
+            run_context = {
+                'full_topic': full_topic,
+                'consumer_group': self.group_id,
+                'expected_signal': self.signal,
+            }
+            self.consumer.subscribe([full_topic])
+            logger.info(f"Running consumer for {run_context!r}")
+
+            # How many errors have we seen in a row? If this climbs too high, exit with error.
+            # Any error counts, here — whether due to a polling failure or a message processing
+            # failure. But only a successfully processed message clears the counter. Just
+            # being able to talk to the broker and get a message (or a normal poll timeout) is
+            # not sufficient to show that progress can be made.
+            consecutive_errors = 0
+
+            while True:
+                # Allow unit tests to break out of loop
+                if self._shut_down_loop:
+                    break
+
+                # Detect probably-broken consumer and exit with error.
+                if CONSECUTIVE_ERRORS_LIMIT and consecutive_errors >= CONSECUTIVE_ERRORS_LIMIT:
+                    raise Exception(f"Too many consecutive errors, exiting ({consecutive_errors} in a row)")
+
+                msg = None
+                try:
+                    msg = self.consumer.poll(timeout=CONSUMER_POLL_TIMEOUT)
+                    if msg is not None:
+                        # Before processing, make sure our db connection is still active
+                        _reconnect_to_db_if_needed()
+
+                        self.emit_signals_from_message(msg)
+                        consecutive_errors = 0
+
+                    self._add_message_monitoring(run_context=run_context, message=msg)
+                except Exception as e:  # pylint: disable=broad-except
+                    consecutive_errors += 1
+                    self.record_event_consuming_error(run_context, e, msg)
+                    # Kill the infinite loop if the error is fatal for the consumer
+                    _, kafka_error = self._get_kafka_message_and_error(message=msg, error=e)
+                    if kafka_error and kafka_error.fatal():
+                        raise e
+                    # Prevent fast error-looping when no event received from broker. Because
+                    # DeserializingConsumer raises rather than returning a Message when it has an
+                    # error() value, this may be triggered even when a Message *was* returned,
+                    # slowing down the queue. This is probably close enough, though.
+                    if msg is None:
+                        time.sleep(POLL_FAILURE_SLEEP)
+                if msg:
+                    # theoretically we could just call consumer.commit() without passing the specific message
+                    # to commit all this consumer's current offset across all partitions since we only process one
+                    # message at a time, but limit it to just the offset/partition of the specified message
+                    # to be super safe
+                    self.consumer.commit(message=msg)
+        finally:
+            self.consumer.close()
+
+    def consume_indefinitely(self, offset_timestamp=None):
+        """
+        Consume events from a topic in an infinite loop.
+
+        Arguments:
+            offset_timestamp (datetime): Optional and deprecated; if supplied, calls
+                ``reset_offsets_and_sleep_indefinitely`` instead. Relying code should
+                switch to calling that method directly.
+        """
+        # TODO: Once this deprecated argument can be removed, just
+        # remove this delegation method entirely and rename
+        # `_consume_indefinitely` to no longer have the `_` prefix.
+        if offset_timestamp is None:
+            self._consume_indefinitely()
+        else:
+            warnings.warn(
+                "Calling consume_indefinitely with offset_timestamp is deprecated; "
+                "please call reset_offsets_and_sleep_indefinitely directly instead."
+            )
+            self.reset_offsets_and_sleep_indefinitely(offset_timestamp)
+
+    def emit_signals_from_message(self, msg):
+        """
+        Determine the correct signal and send the event from the message.
+
+        Arguments:
+            msg (Message): Consumed message.
+        """
+        self._log_message_received(msg)
+
+        # DeserializingConsumer.poll() always returns either a valid message
+        # or None, and raises an exception in all other cases. This means
+        # we don't need to check msg.error() ourselves. But... check it here
+        # anyway for robustness against code changes.
+        if msg.error() is not None:
+            raise UnusableMessageError(
+                f"Polled message had error object (shouldn't happen): {msg.error()!r}"
+            )
+
+        headers = msg.headers() or []  # treat None as []
+
+        event_types = get_message_header_values(headers, HEADER_EVENT_TYPE)
+        if len(event_types) == 0:
+            raise UnusableMessageError(
+                "Missing ce_type header on message, cannot determine signal"
+            )
+        if len(event_types) > 1:
+            raise UnusableMessageError(
+                "Multiple ce_type headers found on message, cannot determine signal"
+            )
+        event_type = event_types[0]
+
+        if event_type != self.signal.event_type:
+            raise UnusableMessageError(
+                f"Signal types do not match. Expected {self.signal.event_type}. "
+                f"Received message of type {event_type}."
+            )
+        try:
+            event_metadata = _get_metadata_from_headers(headers)
+        except Exception as e:
+            raise UnusableMessageError(f"Error determining metadata from message headers: {e}") from e
+        send_results = self.signal.send_event_with_custom_metadata(event_metadata, **msg.value())
+        # Raise an exception if any receivers errored out. This allows logging of the receivers
+        # along with partition, offset, etc. in record_event_consuming_error. Hopefully the
+        # receiver code is idempotent and we can just replay any messages that were involved.
+        self._check_receiver_results(send_results)
+
+        # At the very end, log that a message was processed successfully.
+        # Since we're single-threaded, no other information is needed;
+        # we just need the logger to spit this out with a timestamp.
+        # See ADR: docs/decisions/0010_audit_logging.rst
+        if AUDIT_LOGGING_ENABLED.is_enabled():
+            logger.info('Message from Kafka processed successfully')
+
+    def _check_receiver_results(self, send_results: list):
+        """
+        Raises exception if any of the receivers produced an exception.
+
+        Arguments:
+            send_results: Output of ``send_events``, a list of ``(receiver, response)`` tuples.
+        """
+        error_descriptions = []
+        errors = []
+        for receiver, response in send_results:
+            if not isinstance(response, BaseException):
+                continue
+
+            # Probably every receiver will be a regular function or even a lambda with
+            # these attrs, so this check is just to be safe.
+            try:
+                receiver_name = f"{receiver.__module__}.{receiver.__qualname__}"
+            except AttributeError:
+                receiver_name = str(receiver)
+
+            # The stack traces are already logged by django.dispatcher, so just the error message is fine.
+            error_descriptions.append(f"{receiver_name}={response!r}")
+            errors.append(response)
+
+        if len(error_descriptions) > 0:
+            raise ReceiverError(
+                f"{len(error_descriptions)} receiver(s) out of {len(send_results)} "
+                "produced errors (stack trace elsewhere in logs) "
+                f"when handling signal {self.signal}: {', '.join(error_descriptions)}",
+                errors
+            )
+
+    def _log_message_received(self, msg):
+        """
+        Log that a message was received, for audit log purposes.
+
+        See ADR: docs/decisions/0010_audit_logging.rst
+
+        This will not be sufficient to reconstruct the message; it will just
+        be enough to establish a timeline during debugging and to find a message
+        by offset.
+        """
+        if not AUDIT_LOGGING_ENABLED.is_enabled():
+            return
+
+        try:
+            message_id = last_message_header_value(msg.headers(), HEADER_ID)
+
+            (ts_type, timestamp_ms) = msg.timestamp()
+            if ts_type == TIMESTAMP_NOT_AVAILABLE:
+                timestamp_info = "none"
+            else:
+                # Could be produce time or broker receive time; not going to bother to specify here.
+                timestamp_info = str(timestamp_ms)
+
+            # See ADR for details on why certain fields were included or omitted.
+            logger.info(
+                f'Message received from Kafka: topic={msg.topic()}, partition={msg.partition()}, '
+                f'offset={msg.offset()}, message_id={message_id}, key={msg.key()}, '
+                f'event_timestamp_ms={timestamp_info}'
+            )
+        except Exception as e:  # pragma: no cover  pylint: disable=broad-except
+            # Use this to fix any bugs in what should be benign logging code
+            set_custom_attribute('kafka_logging_error', repr(e))
+
+    def record_event_consuming_error(self, run_context, error, maybe_message):
+        """
+        Record an error caught while consuming an event, both to the logs and to telemetry.
+
+        Arguments:
+            run_context: Dictionary of contextual information: full_topic, consumer_group,
+              and expected_signal.
+            error: An exception instance
+            maybe_message: None if event could not be fetched or decoded, or a Kafka Message if
+              one was successfully deserialized but could not be processed for some reason
+        """
+        context_msg = ", ".join(f"{k}={v!r}" for k, v in run_context.items())
+        # Pulls the event message off the error for certain exceptions.
+        maybe_kafka_message, _ = self._get_kafka_message_and_error(message=maybe_message, error=error)
+        if maybe_kafka_message is None:
+            event_msg = "no event available"
+        else:
+            event_details = {
+                'partition': maybe_kafka_message.partition(),
+                'offset': maybe_kafka_message.offset(),
+                'headers': maybe_kafka_message.headers(),
+                'key': maybe_kafka_message.key(),
+                'value': maybe_kafka_message.value(),
+            }
+            event_msg = f"event details: {event_details!r}"
+
+        try:
+            # This is gross, but our record_exception wrapper doesn't take args at the moment,
+            # and will only read the exception from stack context.
+            raise Exception(error)
+        except BaseException:
+            self._add_message_monitoring(run_context=run_context, message=maybe_kafka_message, error=error)
+            record_exception()
+            logger.exception(
+                f"Error consuming event from Kafka: {error!r} in context {context_msg} -- {event_msg}"
+            )
+
+    def _add_message_monitoring(self, run_context, message, error=None):
+        """
+        Record additional details for monitoring.
+
+        Arguments:
+            run_context: Dictionary of contextual information: full_topic, consumer_group,
+              and expected_signal.
+            message: None if event could not be fetched or decoded, or a Message if one
+              was successfully deserialized but could not be processed for some reason
+            error: (Optional) An exception instance, or None if no error.
+        """
+        try:
+            kafka_message, kafka_error = self._get_kafka_message_and_error(message=message, error=error)
+
+            # .. custom_attribute_name: kafka_topic
+            # .. custom_attribute_description: The full topic of the message or error.
+            set_custom_attribute('kafka_topic', run_context['full_topic'])
+
+            if kafka_message:
+                # .. custom_attribute_name: kafka_partition
+                # .. custom_attribute_description: The partition of the message.
+                set_custom_attribute('kafka_partition', kafka_message.partition())
+                # .. custom_attribute_name: kafka_offset
+                # .. custom_attribute_description: The offset of the message.
+                set_custom_attribute('kafka_offset', kafka_message.offset())
+                headers = kafka_message.headers() or []  # treat None as []
+                message_ids = get_message_header_values(headers, HEADER_ID)
+                if len(message_ids) > 0:
+                    # .. custom_attribute_name: kafka_message_id
+                    # .. custom_attribute_description: The message id which can be matched to the logs. Note that the
+                    #   header in the logs will use 'ce_id'.
+                    set_custom_attribute('kafka_message_id', ",".join(message_ids))
+                event_types = get_message_header_values(headers, HEADER_EVENT_TYPE)
+                if len(event_types) > 0:
+                    # .. custom_attribute_name: kafka_event_type
+                    # .. custom_attribute_description: The event type of the message. Note that the header in the logs
+                    #   will use 'ce_type'.
+                    set_custom_attribute('kafka_event_type', ",".join(event_types))
+
+            if kafka_error:
+                # .. custom_attribute_name: kafka_error_fatal
+                # .. custom_attribute_description: Boolean describing if the error is fatal.
+                set_custom_attribute('kafka_error_fatal', kafka_error.fatal())
+                # .. custom_attribute_name: kafka_error_retriable
+                # .. custom_attribute_description: Boolean describing if the error is retriable.
+                set_custom_attribute('kafka_error_retriable', kafka_error.retriable())
+
+        except Exception as e:  # pragma: no cover  pylint: disable=broad-except
+            # Use this to fix any bugs in what should be benign monitoring code
+            set_custom_attribute('kafka_monitoring_error', repr(e))
+
+    def _get_kafka_message_and_error(self, message, error):
+        """
+        Returns tuple of (kafka_message, kafka_error), if they can be found.
+
+        Notes:
+            * If the message was sent as a parameter, it will be returned.
+            * If the message was not sent, and a KafkaException was sent, the
+                message will be pulled from the exception if it exists.
+            * A KafkaError will be returned if it is either passed directly,
+                or if it was wrapped by a KafkaException.
+
+        Arguments:
+            message: None if event could not be fetched or decoded, or a Message if one
+              was successfully deserialized but could not be processed for some reason
+            error: An exception instance, or None if no error.
+        """
+        if not error or isinstance(error, KafkaError):
+            return message, error
+
+        kafka_error = getattr(error, 'kafka_error', None)
+        # KafkaException uses args[0] to wrap the KafkaError
+        if not kafka_error and len(error.args) > 0 and isinstance(error.args[0], KafkaError):
+            kafka_error = error.args[0]
+
+        kafka_message = getattr(error, 'kafka_message', None)
+        if message and kafka_message and kafka_message != message:  # pragma: no cover
+            # If this unexpected error ever occurs, we can invest in a better error message
+            #   with a test, that includes event header details.
+            logger.error("Error consuming event from Kafka: (UNEXPECTED) The event message did not match"
+                         " the message packaged with the error."
+                         f" -- event message={message!r}, error event message={kafka_message!r}.")
+        # give priority to the passed message, although in theory, it should be the same message if not None
+        kafka_message = message or kafka_message
+
+        return kafka_message, kafka_error
+
+
+class ConsumeEventsCommand(BaseCommand):
+    """
+    Management command for Kafka consumer workers in the event bus.
+    """
+    help = """
+    Consume messages of specified signal type from a Kafka topic and send their data to that signal.
+
+    Example::
+
+        python3 manage.py cms consume_events -t user-login -g user-activity-service \
+            -s org.openedx.learning.auth.session.login.completed.v1
+    """
+
+    def add_arguments(self, parser):
+
+        parser.add_argument(
+            '-t', '--topic',
+            nargs=1,
+            required=True,
+            help='Topic to consume (without environment prefix)'
+        )
+
+        parser.add_argument(
+            '-g', '--group_id',
+            nargs=1,
+            required=True,
+            help='Consumer group id'
+        )
+        parser.add_argument(
+            '-s', '--signal',
+            nargs=1,
+            required=True,
+            help='Type of signal to emit from consumed messages.'
+        )
+        parser.add_argument(
+            '-o', '--offset_time',
+            nargs=1,
+            required=False,
+            default=None,
+            help='The timestamp (in ISO format) that we would like to reset the consumers to. '
+                 'If this is used, the consumers will only reset the offsets of the topic '
+                 'but will not actually consume and process any messages.'
+        )
+
+    def handle(self, *args, **options):
+        if confluent_kafka is None:
+            logger.error(
+                "Cannot consume events because confluent_kafka dependency (or one of its extras) was not installed"
+            )
+            return
+
+        if not KAFKA_CONSUMERS_ENABLED.is_enabled():
+            logger.error("Kafka consumers not enabled, exiting.")
+            return
+
+        try:
+            signal = OpenEdxPublicSignal.get_signal_by_type(options['signal'][0])
+            if options['offset_time'] and options['offset_time'][0] is not None:
+                try:
+                    offset_timestamp = datetime.fromisoformat(options['offset_time'][0])
+                except ValueError:
+                    logger.exception('Could not parse the offset timestamp.')
+                    raise
+            else:
+                offset_timestamp = None
+
+            event_consumer = KafkaEventConsumer(
+                topic=options['topic'][0],
+                group_id=options['group_id'][0],
+                signal=signal,
+            )
+            if offset_timestamp is None:
+                event_consumer.consume_indefinitely()
+            else:
+                event_consumer.reset_offsets_and_sleep_indefinitely(offset_timestamp=offset_timestamp)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Error consuming Kafka events")

--- a/edx_event_bus_redis/internal/producer.py
+++ b/edx_event_bus_redis/internal/producer.py
@@ -1,0 +1,359 @@
+"""
+Produce Kafka events from signals.
+
+Main function is ``create_producer()``, which should be referred to from ``EVENT_BUS_PRODUCER``.
+"""
+
+import json
+import logging
+import threading
+import time
+import weakref
+from functools import lru_cache
+from typing import Any, List, Optional
+
+import attr
+from django.conf import settings
+from django.dispatch import receiver
+from django.test.signals import setting_changed
+from edx_django_utils.monitoring import record_exception
+from openedx_events.data import EventsMetadata
+from openedx_events.event_bus import EventBusProducer
+from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
+from openedx_events.tooling import OpenEdxPublicSignal
+
+from .config import get_full_topic, get_schema_registry_client, load_common_settings
+from .utils import AUDIT_LOGGING_ENABLED, _get_headers_from_metadata
+
+logger = logging.getLogger(__name__)
+
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+try:
+    import confluent_kafka
+    from confluent_kafka import Producer
+    from confluent_kafka.schema_registry.avro import AvroSerializer
+    from confluent_kafka.serialization import MessageField, SerializationContext
+except ImportError:  # pragma: no cover
+    confluent_kafka = None
+
+
+def record_producing_error(error, context):
+    """
+    Record an error in producing an event to both the monitoring system and the regular logs
+
+    Arguments:
+        error: The exception or error raised during producing
+        context: An instance of ProducingContext containing additional information about the message
+    """
+    try:
+        # record_exception() is a wrapper around a New Relic method that can only be called within an except block,
+        # so first re-raise the error
+        raise Exception(error)
+    except BaseException:
+        record_exception()
+        logger.exception(f"Error delivering message to Kafka event bus. {error=!s} {context!r}")
+
+
+def extract_event_key(event_data: dict, event_key_field: str) -> Any:
+    """
+    From an event object, extract a Kafka event key (not yet serialized).
+
+    Arguments:
+        event_data: The event data (kwargs) sent to the signal
+        event_key_field: Path to the event data field to use as the event key (period-delimited
+          string naming the dictionary keys to descend)
+
+    Returns:
+        Key data, which might be an integer, string, dictionary, etc.
+    """
+    field_path = event_key_field.split(".")
+    current_data = event_data
+    for field_name in field_path:
+        if isinstance(current_data, dict):
+            if field_name not in current_data:
+                raise Exception(
+                    f"Could not extract key from event; lookup in {event_key_field} "
+                    f"failed at {field_name!r} in dictionary"
+                )
+            current_data = current_data[field_name]
+        else:
+            if not hasattr(current_data, field_name):
+                raise Exception(
+                    f"Could not extract key from event; lookup in {event_key_field} "
+                    f"failed at {field_name!r} in object"
+                )
+            current_data = getattr(current_data, field_name)
+    return current_data
+
+
+def descend_avro_schema(serializer_schema: dict, field_path: List[str]) -> dict:
+    """
+    Extract a subfield within an Avro schema, recursively.
+
+    Arguments:
+        serializer_schema: An Avro schema (nested dictionaries)
+        field_path: List of strings matching the 'name' of successively deeper subfields
+
+    Returns:
+        Schema for some field
+
+    Note: Avro helpers could be moved to openedx_events.event_bus.avro.serializer to be
+        used for other event bus implementations other than Kafka.
+    """
+    subschema = serializer_schema
+    for field_name in field_path:
+        try:
+            # Either descend into .fields (for dictionaries) or .type.fields (for classes).
+            if 'fields' not in subschema:
+                # Descend through .type wrapper first
+                subschema = subschema['type']
+            field_list = subschema['fields']
+
+            matching = [field for field in field_list if field['name'] == field_name]
+            subschema = matching[0]
+        except Exception as e:
+            raise Exception(
+                f"Error traversing Avro schema along path {field_path!r}; failed at {field_name!r}."
+            ) from e
+    return subschema
+
+
+def extract_key_schema(signal_serializer: AvroSignalSerializer, event_key_field: str) -> str:
+    """
+    From a signal's serializer, extract just the part of the Avro schema that will be used for the Kafka event key.
+
+    Arguments:
+        signal_serializer: The signal serializer to extract a sub-schema from
+        event_key_field: Path to the event data field to use as the event key (period-delimited
+          string naming the dictionary keys to descend)
+
+    Returns:
+        The key's schema, as a string.
+    """
+    subschema = descend_avro_schema(signal_serializer.schema, event_key_field.split("."))
+    # Same as used by AvroSignalSerializer#schema_string in openedx-events
+    return json.dumps(subschema, sort_keys=True)
+
+
+@lru_cache
+def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
+    """
+    Get the key and value serializers for a signal and a key field path.
+
+    This is cached in order to save work re-transforming classes into Avro schemas.
+
+    Arguments:
+        signal: The OpenEdxPublicSignal to make a serializer for.
+        event_key_field: Path to descend in the signal schema to find the subschema for the key
+          (period-delimited string naming the field names to descend).
+
+    Returns:
+        2-tuple of AvroSignalSerializers, for event key and value
+    """
+    client = get_schema_registry_client()
+    if client is None:
+        raise Exception('Cannot create Kafka serializers -- missing library or settings')
+
+    signal_serializer = AvroSignalSerializer(signal)
+
+    def inner_to_dict(event_data, ctx=None):  # pylint: disable=unused-argument
+        """Tells Avro how to turn objects into dictionaries."""
+        return signal_serializer.to_dict(event_data)
+
+    # Serializers for key and value components of Kafka event
+    key_serializer = AvroSerializer(
+        schema_str=extract_key_schema(signal_serializer, event_key_field),
+        schema_registry_client=client,
+        to_dict=inner_to_dict,
+    )
+    value_serializer = AvroSerializer(
+        schema_str=signal_serializer.schema_string(),
+        schema_registry_client=client,
+        to_dict=inner_to_dict,
+    )
+
+    return key_serializer, value_serializer
+
+
+@attr.s(kw_only=True, repr=False)
+class ProducingContext:
+    """
+    Wrapper class to allow us to link a call to produce() with the on_event_deliver callback
+    """
+    full_topic = attr.ib(type=str, default=None)
+    event_key = attr.ib(type=str, default=None)
+    signal = attr.ib(type=OpenEdxPublicSignal, default=None)
+    initial_topic = attr.ib(type=str, default=None)
+    event_key_field = attr.ib(type=str, default=None)
+    event_data = attr.ib(type=dict, default=None)
+    event_metadata = attr.ib(type=EventsMetadata, default=None)
+
+    def __repr__(self):
+        """Create a logging-friendly string"""
+        return " ".join([f"{key}={value!r}" for key, value in attr.asdict(self, recurse=False).items()])
+
+    def on_event_deliver(self, err, evt):
+        """
+        Simple callback method for debugging event production
+
+        If there is any error, log all the known information about the calling context so the event can be recreated
+        and/or resent later. This log will not contain the exact headers but will contain the EventsMetadata object
+        that can be used to recreate them.
+
+        Arguments:
+            err: Error if event production failed
+            evt: Event that was delivered (or failed to be delivered)
+        """
+        if err is not None:
+            record_producing_error(err, self)
+        else:
+            # Audit logging on success. See ADR: docs/decisions/0010_audit_logging.rst
+            if not AUDIT_LOGGING_ENABLED.is_enabled():
+                return
+
+            # `evt.headers()` is None in this callback, so we need to use the bound data.
+            # https://github.com/confluentinc/confluent-kafka-python/issues/574
+            message_id = self.event_metadata.id
+            # See ADR for details on why certain fields were included or omitted.
+            logger.info(
+                f"Message delivered to Kafka event bus: topic={evt.topic()}, partition={evt.partition()}, "
+                f"offset={evt.offset()}, message_id={message_id}, key={evt.key()}"
+            )
+
+
+class KafkaEventProducer(EventBusProducer):
+    """
+    API singleton for event production to Kafka.
+
+    This is just a wrapper around a confluent_kafka Producer that knows how to
+    serialize a signal to event wire format.
+
+    Only one instance (of Producer or this wrapper) should be created,
+    since it is stateful and needs lifecycle management.
+    """
+
+    def __init__(self, producer):
+        self.producer = producer
+
+        threading.Thread(
+            target=poll_indefinitely,
+            name="kafka-producer-poll",
+            args=(weakref.ref(self),),  # allow GC but also thread auto-stop (important for tests!)
+            daemon=True,  # don't block shutdown
+        ).start()
+
+    def send(
+            self, *, signal: OpenEdxPublicSignal, topic: str, event_key_field: str, event_data: dict,
+            event_metadata: EventsMetadata
+    ) -> None:
+        """
+        Send a signal event to the event bus under the specified topic.
+
+        Arguments:
+            signal: The original OpenEdxPublicSignal the event was sent to
+            topic: The base (un-prefixed) event bus topic for the event
+            event_key_field: Path to the event data field to use as the event key (period-delimited
+              string naming the dictionary keys to descend)
+            event_data: The event data (kwargs) sent to the signal
+            event_metadata: An EventsMetadata object with all the metadata necessary for the CloudEvent spec
+        """
+
+        # keep track of the initial arguments for recreating the event in the logs if necessary later
+        context = ProducingContext(signal=signal, initial_topic=topic, event_key_field=event_key_field,
+                                   event_data=event_data, event_metadata=event_metadata)
+        try:
+            full_topic = get_full_topic(topic)
+            context.full_topic = full_topic
+
+            event_key = extract_event_key(event_data, event_key_field)
+            context.event_key = event_key
+            headers = _get_headers_from_metadata(event_metadata=event_metadata)
+
+            key_serializer, value_serializer = get_serializers(signal, event_key_field)
+            key_bytes = key_serializer(event_key, SerializationContext(full_topic, MessageField.KEY, headers))
+            value_bytes = value_serializer(event_data, SerializationContext(full_topic, MessageField.VALUE, headers))
+            self.producer.produce(
+                full_topic, key=key_bytes, value=value_bytes, headers=headers,
+                on_delivery=context.on_event_deliver,
+            )
+
+            # Opportunistically ensure any pending callbacks from recent event-sends are triggered.
+            # This ensures that we're polling at least as often as we're producing, which is a
+            # reasonable balance. However, if events are infrequent, it doesn't ensure that
+            # callbacks happen in a timely fashion, and the last event emitted before shutdown
+            # would never get a delivery callback. That's why there's also a thread calling
+            # poll(0) on a regular interval (see `poll_indefinitely`).
+            self.producer.poll(0)
+        except Exception as e:  # pylint: disable=broad-except
+            # Errors caused by the produce call should be handled by the on_delivery callback.
+            # Here we might expect serialization errors, or any errors from preparing to produce.
+            record_producing_error(e, context)
+
+    def prepare_for_shutdown(self):
+        """
+        Prepare producer for a clean shutdown.
+
+        Flush pending outbound events, wait for acknowledgement, and process callbacks.
+        """
+        self.producer.flush(-1)
+
+
+def poll_indefinitely(api_weakref: KafkaEventProducer):
+    """
+    Poll the producer indefinitely to ensure delivery/stats/etc. callbacks are triggered.
+
+    The thread stops automatically once the producer is garbage-collected.
+
+    See ADR for more information:
+    https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0007-producer-polling.rst
+    """
+    # The reason we hold a weakref to the whole KafkaEventProducer and
+    # not directly to the Producer itself is that you just can't make
+    # a weakref to the latter (perhaps because it's a C object.)
+
+    # .. setting_name: EVENT_BUS_KAFKA_POLL_INTERVAL_SEC
+    # .. setting_default: 1.0
+    # .. setting_description: How frequently to poll the event-bus-kafka producer. This should
+    #   be small enough that there's not too much latency in triggering delivery callbacks once
+    #   a message has been acknowledged, but there's no point in setting it any lower than the
+    #   expected round-trip-time of message delivery and acknowledgement. (100 ms – 5 s is
+    #   probably a reasonable range.)
+    poll_interval_seconds = getattr(settings, 'EVENT_BUS_KAFKA_POLL_INTERVAL_SEC', 1.0)
+    while True:
+        time.sleep(poll_interval_seconds)
+
+        # Temporarily hold a strong ref to the producer API singleton
+        api_object = api_weakref()
+        if api_object is None:
+            return
+        try:
+            api_object.producer.poll(0)
+        except BaseException:
+            logger.exception("Event bus producer polling loop encountered exception (continuing)")
+            record_exception()
+        finally:
+            # Get rid of that strong ref again
+            api_object = None
+
+
+def create_producer() -> Optional[KafkaEventProducer]:
+    """
+    Create a Producer API instance. Caller should cache the returned object.
+
+    If confluent-kafka library or essential settings are missing, warn and return None.
+    """
+    if not confluent_kafka:  # pragma: no cover
+        logger.warning('Library confluent-kafka not available. Cannot create event producer.')
+        return None
+
+    producer_settings = load_common_settings()
+    if producer_settings is None:
+        return None
+
+    return KafkaEventProducer(Producer(producer_settings))
+
+
+@receiver(setting_changed)
+def _reset_caches(sender, **kwargs):  # pylint: disable=unused-argument
+    """Reset caches when settings change during unit tests."""
+    get_serializers.cache_clear()

--- a/edx_event_bus_redis/internal/producer.py
+++ b/edx_event_bus_redis/internal/producer.py
@@ -4,37 +4,19 @@ Produce Kafka events from signals.
 Main function is ``create_producer()``, which should be referred to from ``EVENT_BUS_PRODUCER``.
 """
 
-import json
 import logging
-import threading
-import time
-import weakref
-from functools import lru_cache
-from typing import Any, List, Optional
+from typing import Optional
 
 import attr
-from django.conf import settings
-from django.dispatch import receiver
-from django.test.signals import setting_changed
 from edx_django_utils.monitoring import record_exception
 from openedx_events.data import EventsMetadata
 from openedx_events.event_bus import EventBusProducer
-from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
 from openedx_events.tooling import OpenEdxPublicSignal
 
-from .config import get_full_topic, get_schema_registry_client, load_common_settings
-from .utils import AUDIT_LOGGING_ENABLED, get_headers_from_metadata
+from .config import get_full_topic, load_common_settings
+from .utils import AUDIT_LOGGING_ENABLED
 
 logger = logging.getLogger(__name__)
-
-# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
-try:
-    import confluent_kafka
-    from confluent_kafka import Producer
-    from confluent_kafka.schema_registry.avro import AvroSerializer
-    from confluent_kafka.serialization import MessageField, SerializationContext
-except ImportError:  # pragma: no cover
-    confluent_kafka = None
 
 
 def record_producing_error(error, context):
@@ -52,127 +34,6 @@ def record_producing_error(error, context):
     except BaseException:
         record_exception()
         logger.exception(f"Error delivering message to Kafka event bus. {error=!s} {context!r}")
-
-
-def extract_event_key(event_data: dict, event_key_field: str) -> Any:
-    """
-    From an event object, extract a Kafka event key (not yet serialized).
-
-    Arguments:
-        event_data: The event data (kwargs) sent to the signal
-        event_key_field: Path to the event data field to use as the event key (period-delimited
-          string naming the dictionary keys to descend)
-
-    Returns:
-        Key data, which might be an integer, string, dictionary, etc.
-    """
-    field_path = event_key_field.split(".")
-    current_data = event_data
-    for field_name in field_path:
-        if isinstance(current_data, dict):
-            if field_name not in current_data:
-                raise Exception(
-                    f"Could not extract key from event; lookup in {event_key_field} "
-                    f"failed at {field_name!r} in dictionary"
-                )
-            current_data = current_data[field_name]
-        else:
-            if not hasattr(current_data, field_name):
-                raise Exception(
-                    f"Could not extract key from event; lookup in {event_key_field} "
-                    f"failed at {field_name!r} in object"
-                )
-            current_data = getattr(current_data, field_name)
-    return current_data
-
-
-def descend_avro_schema(serializer_schema: dict, field_path: List[str]) -> dict:
-    """
-    Extract a subfield within an Avro schema, recursively.
-
-    Arguments:
-        serializer_schema: An Avro schema (nested dictionaries)
-        field_path: List of strings matching the 'name' of successively deeper subfields
-
-    Returns:
-        Schema for some field
-
-    Note: Avro helpers could be moved to openedx_events.event_bus.avro.serializer to be
-        used for other event bus implementations other than Kafka.
-    """
-    subschema = serializer_schema
-    for field_name in field_path:
-        try:
-            # Either descend into .fields (for dictionaries) or .type.fields (for classes).
-            if 'fields' not in subschema:
-                # Descend through .type wrapper first
-                subschema = subschema['type']
-            field_list = subschema['fields']
-
-            matching = [field for field in field_list if field['name'] == field_name]
-            subschema = matching[0]
-        except Exception as e:
-            raise Exception(
-                f"Error traversing Avro schema along path {field_path!r}; failed at {field_name!r}."
-            ) from e
-    return subschema
-
-
-def extract_key_schema(signal_serializer: AvroSignalSerializer, event_key_field: str) -> str:
-    """
-    From a signal's serializer, extract just the part of the Avro schema that will be used for the Kafka event key.
-
-    Arguments:
-        signal_serializer: The signal serializer to extract a sub-schema from
-        event_key_field: Path to the event data field to use as the event key (period-delimited
-          string naming the dictionary keys to descend)
-
-    Returns:
-        The key's schema, as a string.
-    """
-    subschema = descend_avro_schema(signal_serializer.schema, event_key_field.split("."))
-    # Same as used by AvroSignalSerializer#schema_string in openedx-events
-    return json.dumps(subschema, sort_keys=True)
-
-
-@lru_cache
-def get_serializers(signal: OpenEdxPublicSignal, event_key_field: str):
-    """
-    Get the key and value serializers for a signal and a key field path.
-
-    This is cached in order to save work re-transforming classes into Avro schemas.
-
-    Arguments:
-        signal: The OpenEdxPublicSignal to make a serializer for.
-        event_key_field: Path to descend in the signal schema to find the subschema for the key
-          (period-delimited string naming the field names to descend).
-
-    Returns:
-        2-tuple of AvroSignalSerializers, for event key and value
-    """
-    client = get_schema_registry_client()
-    if client is None:
-        raise Exception('Cannot create Kafka serializers -- missing library or settings')
-
-    signal_serializer = AvroSignalSerializer(signal)
-
-    def inner_to_dict(event_data, ctx=None):  # pylint: disable=unused-argument
-        """Tells Avro how to turn objects into dictionaries."""
-        return signal_serializer.to_dict(event_data)
-
-    # Serializers for key and value components of Kafka event
-    key_serializer = AvroSerializer(
-        schema_str=extract_key_schema(signal_serializer, event_key_field),
-        schema_registry_client=client,
-        to_dict=inner_to_dict,
-    )
-    value_serializer = AvroSerializer(
-        schema_str=signal_serializer.schema_string(),
-        schema_registry_client=client,
-        to_dict=inner_to_dict,
-    )
-
-    return key_serializer, value_serializer
 
 
 @attr.s(kw_only=True, repr=False)
@@ -221,7 +82,7 @@ class ProducingContext:
             )
 
 
-class KafkaEventProducer(EventBusProducer):
+class RedisEventProducer(EventBusProducer):
     """
     API singleton for event production to Kafka.
 
@@ -232,15 +93,8 @@ class KafkaEventProducer(EventBusProducer):
     since it is stateful and needs lifecycle management.
     """
 
-    def __init__(self, producer):
-        self.producer = producer
-
-        threading.Thread(
-            target=poll_indefinitely,
-            name="kafka-producer-poll",
-            args=(weakref.ref(self),),  # allow GC but also thread auto-stop (important for tests!)
-            daemon=True,  # don't block shutdown
-        ).start()
+    def __init__(self, client):
+        self.client = client
 
     def send(
             self, *, signal: OpenEdxPublicSignal, topic: str, event_key_field: str, event_data: dict,
@@ -265,95 +119,23 @@ class KafkaEventProducer(EventBusProducer):
             full_topic = get_full_topic(topic)
             context.full_topic = full_topic
 
-            event_key = extract_event_key(event_data, event_key_field)
-            context.event_key = event_key
-            headers = get_headers_from_metadata(event_metadata=event_metadata)
-
-            key_serializer, value_serializer = get_serializers(signal, event_key_field)
-            key_bytes = key_serializer(event_key, SerializationContext(full_topic, MessageField.KEY, headers))
-            value_bytes = value_serializer(event_data, SerializationContext(full_topic, MessageField.VALUE, headers))
-            self.producer.produce(
-                full_topic, key=key_bytes, value=value_bytes, headers=headers,
-                on_delivery=context.on_event_deliver,
-            )
-
-            # Opportunistically ensure any pending callbacks from recent event-sends are triggered.
-            # This ensures that we're polling at least as often as we're producing, which is a
-            # reasonable balance. However, if events are infrequent, it doesn't ensure that
-            # callbacks happen in a timely fashion, and the last event emitted before shutdown
-            # would never get a delivery callback. That's why there's also a thread calling
-            # poll(0) on a regular interval (see `poll_indefinitely`).
-            self.producer.poll(0)
+            # TODO: add event to redis stream
         except Exception as e:  # pylint: disable=broad-except
             # Errors caused by the produce call should be handled by the on_delivery callback.
             # Here we might expect serialization errors, or any errors from preparing to produce.
             record_producing_error(e, context)
 
-    def prepare_for_shutdown(self):
-        """
-        Prepare producer for a clean shutdown.
 
-        Flush pending outbound events, wait for acknowledgement, and process callbacks.
-        """
-        self.producer.flush(-1)
-
-
-def poll_indefinitely(api_weakref: KafkaEventProducer):
-    """
-    Poll the producer indefinitely to ensure delivery/stats/etc. callbacks are triggered.
-
-    The thread stops automatically once the producer is garbage-collected.
-
-    See ADR for more information:
-    https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0007-producer-polling.rst
-    """
-    # The reason we hold a weakref to the whole KafkaEventProducer and
-    # not directly to the Producer itself is that you just can't make
-    # a weakref to the latter (perhaps because it's a C object.)
-
-    # .. setting_name: EVENT_BUS_KAFKA_POLL_INTERVAL_SEC
-    # .. setting_default: 1.0
-    # .. setting_description: How frequently to poll the event-bus-kafka producer. This should
-    #   be small enough that there's not too much latency in triggering delivery callbacks once
-    #   a message has been acknowledged, but there's no point in setting it any lower than the
-    #   expected round-trip-time of message delivery and acknowledgement. (100 ms – 5 s is
-    #   probably a reasonable range.)
-    poll_interval_seconds = getattr(settings, 'EVENT_BUS_KAFKA_POLL_INTERVAL_SEC', 1.0)
-    while True:
-        time.sleep(poll_interval_seconds)
-
-        # Temporarily hold a strong ref to the producer API singleton
-        api_object = api_weakref()
-        if api_object is None:
-            return
-        try:
-            api_object.producer.poll(0)
-        except BaseException:
-            logger.exception("Event bus producer polling loop encountered exception (continuing)")
-            record_exception()
-        finally:
-            # Get rid of that strong ref again
-            api_object = None
-
-
-def create_producer() -> Optional[KafkaEventProducer]:
+def create_producer() -> Optional[RedisEventProducer]:
     """
     Create a Producer API instance. Caller should cache the returned object.
 
     If confluent-kafka library or essential settings are missing, warn and return None.
     """
-    if not confluent_kafka:  # pragma: no cover
-        logger.warning('Library confluent-kafka not available. Cannot create event producer.')
-        return None
-
     producer_settings = load_common_settings()
     if producer_settings is None:
         return None
 
-    return KafkaEventProducer(Producer(producer_settings))
-
-
-@receiver(setting_changed)
-def _reset_caches(sender, **kwargs):  # pylint: disable=unused-argument
-    """Reset caches when settings change during unit tests."""
-    get_serializers.cache_clear()
+    # TODO create redis client
+    client = None
+    return RedisEventProducer(client)

--- a/edx_event_bus_redis/internal/producer.py
+++ b/edx_event_bus_redis/internal/producer.py
@@ -30,7 +30,7 @@ def record_producing_error(error, context):
     try:
         # record_exception() is a wrapper around a New Relic method that can only be called within an except block,
         # so first re-raise the error
-        raise Exception(error)
+        raise Exception(error)  # pylint: disable=broad-exception-raised
     except BaseException:
         record_exception()
         logger.exception(f"Error delivering message to Kafka event bus. {error=!s} {context!r}")

--- a/edx_event_bus_redis/internal/producer.py
+++ b/edx_event_bus_redis/internal/producer.py
@@ -23,7 +23,7 @@ from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
 from openedx_events.tooling import OpenEdxPublicSignal
 
 from .config import get_full_topic, get_schema_registry_client, load_common_settings
-from .utils import AUDIT_LOGGING_ENABLED, _get_headers_from_metadata
+from .utils import AUDIT_LOGGING_ENABLED, get_headers_from_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +267,7 @@ class KafkaEventProducer(EventBusProducer):
 
             event_key = extract_event_key(event_data, event_key_field)
             context.event_key = event_key
-            headers = _get_headers_from_metadata(event_metadata=event_metadata)
+            headers = get_headers_from_metadata(event_metadata=event_metadata)
 
             key_serializer, value_serializer = get_serializers(signal, event_key_field)
             key_bytes = key_serializer(event_key, SerializationContext(full_topic, MessageField.KEY, headers))

--- a/edx_event_bus_redis/internal/tests/test_config.py
+++ b/edx_event_bus_redis/internal/tests/test_config.py
@@ -1,0 +1,77 @@
+"""
+Test common configuration loading.
+"""
+
+from unittest import TestCase
+
+from django.test.utils import override_settings
+
+from edx_event_bus_kafka.internal import config
+
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+try:
+    from confluent_kafka.schema_registry import SchemaRegistryClient
+except ImportError:  # pragma: no cover
+    pass
+
+
+class TestSchemaRegistryClient(TestCase):
+    """
+    Test client creation.
+    """
+    def test_unconfigured(self):
+        assert config.get_schema_registry_client() is None
+
+    def test_configured(self):
+        with override_settings(EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345'):
+            assert isinstance(config.get_schema_registry_client(), SchemaRegistryClient)
+
+        # Check if it's cached, too
+        assert config.get_schema_registry_client() is config.get_schema_registry_client()
+
+
+class TestCommonSettings(TestCase):
+    """
+    Test loading of settings common to producer and consumer.
+    """
+    def test_unconfigured(self):
+        assert config.load_common_settings() is None
+
+    def test_minimal(self):
+        with override_settings(
+                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+        ):
+            assert config.load_common_settings() == {
+                'bootstrap.servers': 'localhost:54321',
+            }
+
+    def test_full(self):
+        with override_settings(
+                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+                EVENT_BUS_KAFKA_API_KEY='some_other_key',
+                EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
+        ):
+            assert config.load_common_settings() == {
+                'bootstrap.servers': 'localhost:54321',
+                'sasl.mechanism': 'PLAIN',
+                'security.protocol': 'SASL_SSL',
+                'sasl.username': 'some_other_key',
+                'sasl.password': 'some_other_secret',
+            }
+
+
+class TestTopicPrefixing(TestCase):
+    """
+    Test autoprefixing of base topic.
+    """
+    def test_no_prefix(self):
+        assert config.get_full_topic('user-logins') == 'user-logins'
+
+    @override_settings(EVENT_BUS_TOPIC_PREFIX='')
+    def test_empty_string_prefix(self):
+        """Check that empty string is treated the same as None."""
+        assert config.get_full_topic('user-logins') == 'user-logins'
+
+    @override_settings(EVENT_BUS_TOPIC_PREFIX='stage')
+    def test_regular_prefix(self):
+        assert config.get_full_topic('user-logins') == 'stage-user-logins'

--- a/edx_event_bus_redis/internal/tests/test_config.py
+++ b/edx_event_bus_redis/internal/tests/test_config.py
@@ -24,6 +24,7 @@ class TestCommonSettings(TestCase):
                 'url': 'redis://:password@locahost:6379/0',
             }
 
+
 class TestTopicPrefixing(TestCase):
     """
     Test autoprefixing of base topic.

--- a/edx_event_bus_redis/internal/tests/test_config.py
+++ b/edx_event_bus_redis/internal/tests/test_config.py
@@ -6,28 +6,7 @@ from unittest import TestCase
 
 from django.test.utils import override_settings
 
-from edx_event_bus_kafka.internal import config
-
-# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
-try:
-    from confluent_kafka.schema_registry import SchemaRegistryClient
-except ImportError:  # pragma: no cover
-    pass
-
-
-class TestSchemaRegistryClient(TestCase):
-    """
-    Test client creation.
-    """
-    def test_unconfigured(self):
-        assert config.get_schema_registry_client() is None
-
-    def test_configured(self):
-        with override_settings(EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345'):
-            assert isinstance(config.get_schema_registry_client(), SchemaRegistryClient)
-
-        # Check if it's cached, too
-        assert config.get_schema_registry_client() is config.get_schema_registry_client()
+from edx_event_bus_redis.internal import config
 
 
 class TestCommonSettings(TestCase):
@@ -39,26 +18,11 @@ class TestCommonSettings(TestCase):
 
     def test_minimal(self):
         with override_settings(
-                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+                EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@locahost:6379/0',
         ):
             assert config.load_common_settings() == {
-                'bootstrap.servers': 'localhost:54321',
+                'url': 'redis://:password@locahost:6379/0',
             }
-
-    def test_full(self):
-        with override_settings(
-                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-                EVENT_BUS_KAFKA_API_KEY='some_other_key',
-                EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
-        ):
-            assert config.load_common_settings() == {
-                'bootstrap.servers': 'localhost:54321',
-                'sasl.mechanism': 'PLAIN',
-                'security.protocol': 'SASL_SSL',
-                'sasl.username': 'some_other_key',
-                'sasl.password': 'some_other_secret',
-            }
-
 
 class TestTopicPrefixing(TestCase):
     """

--- a/edx_event_bus_redis/internal/tests/test_consumer.py
+++ b/edx_event_bus_redis/internal/tests/test_consumer.py
@@ -1,0 +1,655 @@
+"""
+Tests for event_consumer module.
+"""
+
+import copy
+from datetime import datetime
+from unittest.mock import Mock, call, patch
+from uuid import uuid1
+
+import ddt
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+from openedx_events.learning.data import UserData, UserPersonalData
+from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
+
+from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer, ReceiverError, UnusableMessageError
+from edx_event_bus_kafka.internal.tests.test_utils import FakeMessage, side_effects
+from edx_event_bus_kafka.management.commands.consume_events import Command
+
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+try:
+    from confluent_kafka import (
+        TIMESTAMP_CREATE_TIME,
+        TIMESTAMP_NOT_AVAILABLE,
+        KafkaError,
+        KafkaException,
+        TopicPartition,
+    )
+    from confluent_kafka.error import ConsumeError
+except ImportError as e:  # pragma: no cover
+    pass
+
+
+def fake_receiver_returns_quietly(**kwargs):
+    return
+
+
+def fake_receiver_raises_error(**kwargs):
+    raise Exception("receiver whoops")
+
+
+@override_settings(
+    EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='https://test-url',
+    EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='bootstrap-servers',
+    EVENT_BUS_KAFKA_API_KEY='test-key',
+    EVENT_BUS_KAFKA_API_SECRET='test-secret',
+)
+@ddt.ddt
+class TestEmitSignals(TestCase):
+    """
+    Tests for message parsing and signal-sending.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.normal_event_data = {
+            'user': UserData(
+                id=123,
+                is_active=True,
+                pii=UserPersonalData(
+                    username='foobob',
+                    email='bob@foo.example',
+                    name='Bob Foo'
+                )
+            )
+        }
+        self.message_id = uuid1()
+        self.message_id_bytes = str(self.message_id).encode('utf-8')
+
+        self.signal_type_bytes = b'org.openedx.learning.auth.session.login.completed.v1'
+        self.signal_type = self.signal_type_bytes.decode('utf-8')
+        self.normal_message = FakeMessage(
+            topic='local-some-topic',
+            partition=2,
+            offset=12345,
+            headers=[
+                ('ce_id', self.message_id_bytes),
+                ('ce_type', self.signal_type_bytes),
+            ],
+            key=b'\x00\x00\x00\x00\x01\x0cfoobob',  # Avro, as observed in manual test
+            value=self.normal_event_data,
+            error=None,
+            timestamp=(TIMESTAMP_CREATE_TIME, 1675114920123),
+        )
+        self.mock_receiver = Mock()
+        self.signal = SESSION_LOGIN_COMPLETED
+        self.signal.connect(fake_receiver_returns_quietly)
+        self.signal.connect(fake_receiver_raises_error)
+        self.signal.connect(self.mock_receiver)
+        self.event_consumer = KafkaEventConsumer('some-topic', 'test_group_id', self.signal)
+
+    def tearDown(self):
+        self.signal.disconnect(fake_receiver_returns_quietly)
+        self.signal.disconnect(fake_receiver_raises_error)
+        self.signal.disconnect(self.mock_receiver)
+
+    def assert_signal_sent_with(self, signal, data):
+        """
+        Check that a signal-send came in as expected to the mock receiver.
+        """
+        self.mock_receiver.assert_called_once()
+        call_kwargs = self.mock_receiver.call_args[1]
+
+        # Standard signal stuff
+        assert call_kwargs['signal'] == signal
+        assert call_kwargs['sender'] is None
+
+        # There should just be one key-value pair in the data for all OpenEdxPublicEvents
+        ((event_top_key, event_contents),) = data.items()
+        assert call_kwargs[event_top_key] == event_contents
+
+        # There should also be a metadata key -- spot-check it
+        metadata = call_kwargs['metadata']
+        assert metadata.event_type == signal.event_type
+        assert metadata.sourcehost is not None
+
+    @override_settings(EVENT_BUS_KAFKA_CONSUMERS_ENABLED=False)
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    def test_consume_loop_disabled(self, mock_logger):
+        self.event_consumer.consume_indefinitely()  # returns at all
+        mock_logger.error.assert_called_once_with("Kafka consumers not enabled, exiting.")
+
+    def test_reset_offsets_and_sleep_indefinitely(self):
+        test_time = datetime.now()
+        self.event_consumer.consumer = Mock()
+        self.event_consumer._shut_down()  # pylint: disable=protected-access
+        self.event_consumer.reset_offsets_and_sleep_indefinitely(offset_timestamp=test_time)
+        reset_offsets = self.event_consumer.consumer.subscribe.call_args[1]['on_assign']
+        partitions = [TopicPartition('dummy_topic', 0, 0), TopicPartition('dummy_topic', 1, 0)]
+        self.event_consumer.consumer.offsets_for_times.return_value = partitions
+
+        # This is usually called by Kafka after assignment of partitions. For testing, we are calling
+        # it directly.
+        reset_offsets(self.event_consumer.consumer, partitions)
+
+        test_time_ms = int(test_time.timestamp()*1000)
+
+        # TopicPartition objects are considered equal if the topic and partition are equal, regardless of offset
+        # so we need to compare the objects by property
+        [partition_0, partition_1] = self.event_consumer.consumer.offsets_for_times.call_args.args[0]
+        assert partition_0.offset == test_time_ms
+        assert partition_0.topic == 'dummy_topic'
+        assert partition_0.partition == 0
+
+        assert partition_1.offset == test_time_ms
+        assert partition_1.topic == 'dummy_topic'
+        assert partition_1.partition == 1
+
+    @override_settings(
+        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+        EVENT_BUS_TOPIC_PREFIX='local',
+    )
+    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.time.sleep', autospec=True)
+    def test_consume_loop(self, mock_sleep, mock_logger, mock_set_custom_attribute):
+        """
+        Check the basic loop lifecycle.
+        """
+        def raise_exception():
+            raise Exception("something broke")
+
+        # How the emit_signals_from_message() mock will behave on each successive call.
+        mock_emit_side_effects = [
+            lambda: None,  # accept and ignore a message
+            raise_exception,
+            lambda: None,  # accept another message (exception didn't break loop)
+
+            # Final "call" just serves to stop the loop
+            self.event_consumer._shut_down  # pylint: disable=protected-access
+        ]
+
+        with patch.object(
+                self.event_consumer, 'emit_signals_from_message',
+                side_effect=side_effects(mock_emit_side_effects),
+        ) as mock_emit:
+            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
+            self.event_consumer.consumer = mock_consumer
+            self.event_consumer.consume_indefinitely()
+
+        # Check that each of the mocked out methods got called as expected.
+        mock_consumer.subscribe.assert_called_once_with(['local-some-topic'])
+        # Check that emit was called the expected number of times
+        assert mock_emit.call_args_list == [call(self.normal_message)] * len(mock_emit_side_effects)
+
+        # Check that there was one error log message and that it contained all the right parts,
+        # in some order.
+        mock_logger.exception.assert_called_once()
+        (exc_log_msg,) = mock_logger.exception.call_args.args
+        assert "Error consuming event from Kafka: Exception('something broke') in context" in exc_log_msg
+        assert "full_topic='local-some-topic'" in exc_log_msg
+        assert "consumer_group='test_group_id'" in exc_log_msg
+        assert ("expected_signal=<OpenEdxPublicSignal: "
+                "org.openedx.learning.auth.session.login.completed.v1>") in exc_log_msg
+        assert "-- event details: " in exc_log_msg
+        assert "'partition': 2" in exc_log_msg
+        assert "'offset': 12345" in exc_log_msg
+        assert f"'headers': [('ce_id', b'{self.message_id}'), " \
+               "('ce_type', b'org.openedx.learning.auth.session.login.completed.v1')]" in exc_log_msg
+        assert "'key': b'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob'" in exc_log_msg
+        assert "email='bob@foo.example'" in exc_log_msg
+
+        mock_set_custom_attribute.assert_has_calls(
+            [
+                call("kafka_topic", "local-some-topic"),
+                call("kafka_message_id", str(self.message_id)),
+                call("kafka_partition", 2),
+                call("kafka_offset", 12345),
+                call("kafka_event_type", "org.openedx.learning.auth.session.login.completed.v1"),
+            ] * len(mock_emit_side_effects),
+            any_order=True,
+        )
+
+        # Check that each message got committed (including the errored ones)
+        assert len(mock_consumer.commit.call_args_list) == len(mock_emit_side_effects)
+
+        mock_sleep.assert_not_called()
+        mock_consumer.close.assert_called_once_with()  # since shutdown was requested, not because of exception
+
+    @override_settings(
+        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+        EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT=4,
+    )
+    def test_consecutive_error_limit(self):
+        """Confirm that consecutive errors can break out of loop."""
+        def raise_exception():
+            raise Exception("something broke")
+
+        exception_count = 4
+
+        with patch.object(
+                self.event_consumer, 'emit_signals_from_message',
+                side_effect=side_effects([raise_exception] * exception_count)
+        ) as mock_emit:
+            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
+            self.event_consumer.consumer = mock_consumer
+            with pytest.raises(Exception) as exc_info:
+                self.event_consumer.consume_indefinitely()
+
+        assert mock_emit.call_args_list == [call(self.normal_message)] * exception_count
+        assert exc_info.value.args == ("Too many consecutive errors, exiting (4 in a row)",)
+
+    @override_settings(
+        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+    )
+    @patch('edx_event_bus_kafka.internal.consumer.connection')
+    @ddt.data(
+        (False, False, False),  # no connection, don't reconnect
+        (True, False, True),  # connection unusable, reconnect expected
+        (False, True, False),  # usable connection, no need to reconnect
+    )
+    @ddt.unpack
+    def test_connection_reset(self, has_connection, is_usable, reconnect_expected, mock_connection):
+        """Confirm we reconnect to the database as required"""
+        if not has_connection:
+            mock_connection.connection = None
+        mock_connection.is_usable.return_value = is_usable
+
+        with patch.object(
+                self.event_consumer, 'emit_signals_from_message',
+                side_effect=side_effects([self.event_consumer._shut_down])  # pylint: disable=protected-access
+        ):
+            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
+            self.event_consumer.consumer = mock_consumer
+            self.event_consumer.consume_indefinitely()
+
+        if reconnect_expected:
+            mock_connection.connect.assert_called_once()
+        else:
+            mock_connection.connect.assert_not_called()
+
+    @override_settings(
+        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+        EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT=4,
+    )
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.time.sleep', autospec=True)
+    def test_no_consume_with_offsets(self, mock_sleep, mock_logger):
+        mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
+        self.event_consumer.consumer = mock_consumer
+        mock_sleep.side_effect = side_effects([self.event_consumer._shut_down])  # pylint: disable=protected-access
+        self.event_consumer.consume_indefinitely(offset_timestamp=0)
+        mock_sleep.assert_called_with(30)
+        mock_logger.info.assert_any_call('Offsets are being reset. Sleeping instead of consuming events.')
+
+    @override_settings(
+        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+        EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT=4,
+    )
+    def test_non_consecutive_errors(self):
+        """Confirm that non-consecutive errors may not break out of loop."""
+        def raise_exception():
+            raise Exception("something broke")
+
+        mock_emit_side_effects = [
+            raise_exception, raise_exception,
+            lambda: None,  # an iteration that doesn't raise an exception
+            raise_exception, raise_exception,
+            # Stop the loop, since the non-consecutive exceptions won't do it
+            self.event_consumer._shut_down,  # pylint: disable=protected-access
+        ]
+
+        with patch.object(
+                self.event_consumer, 'emit_signals_from_message',
+                side_effect=side_effects(mock_emit_side_effects)
+        ) as mock_emit:
+            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
+            self.event_consumer.consumer = mock_consumer
+            self.event_consumer.consume_indefinitely()  # exits normally
+
+        assert mock_emit.call_args_list == [call(self.normal_message)] * len(mock_emit_side_effects)
+
+    TEST_FAILED_MESSAGE = FakeMessage(
+        partition=7,
+        offset=6789,
+        headers=[
+            ('ce_id', b'1111-1111'),
+            ('ce_type', b'org.openedx.learning.auth.session.login.completed.v1'),
+        ],
+        key=b'\x00\x00\x00\x00\x01\x0cfoobob',  # Avro, as observed in manual test
+        value=b'XXX',
+    )
+    TEST_KAFKA_ERROR = KafkaError(2, fatal=False, retriable=True)
+    TEST_CONSUME_ERROR_NO_MESSAGE = ConsumeError(TEST_KAFKA_ERROR, exception=None, kafka_message=None)
+    TEST_CONSUME_ERROR_WITH_MESSAGE = ConsumeError(TEST_KAFKA_ERROR, exception=None, kafka_message=TEST_FAILED_MESSAGE)
+    TEST_KAFKA_EXCEPTION = KafkaException(TEST_KAFKA_ERROR)
+    TEST_KAFKA_FATAL_ERROR = KafkaError(2, fatal=True, retriable=True)
+    TEST_CONSUME_ERROR_FATAL = ConsumeError(TEST_KAFKA_FATAL_ERROR, exception=None, kafka_message=None)
+
+    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.time.sleep', autospec=True)
+    @override_settings(
+        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+        EVENT_BUS_TOPIC_PREFIX='local',
+        EVENT_BUS_KAFKA_CONSUMER_POLL_FAILURE_SLEEP=1
+    )
+    @ddt.data(
+        (Exception("something random"), False, False, False),
+        (TEST_CONSUME_ERROR_NO_MESSAGE, False, True, False),
+        (TEST_CONSUME_ERROR_WITH_MESSAGE, True, True, False),
+        (TEST_KAFKA_EXCEPTION, False, True, False),
+        (TEST_CONSUME_ERROR_FATAL, False, True, True),
+    )
+    @ddt.unpack
+    def test_record_error_for_various_errors(
+        self, exception, has_message, has_kafka_error, is_fatal, mock_sleep, mock_logger, mock_set_custom_attribute,
+    ):
+        """
+        Covers reporting of an error in the consumer loop for various types of errors.
+        """
+        def poll_side_effect(*args, **kwargs):
+            # Only run one iteration
+            self.event_consumer._shut_down()  # pylint: disable=protected-access
+            raise exception
+
+        mock_consumer = Mock(**{'poll.side_effect': poll_side_effect}, autospec=True)
+        self.event_consumer.consumer = mock_consumer
+        if is_fatal:
+            with pytest.raises(ConsumeError) as exc_info:
+                self.event_consumer.consume_indefinitely()
+            assert exc_info.value == exception
+        else:
+            self.event_consumer.consume_indefinitely()
+
+        # Check that there was one exception log message and that it contained all the right parts,
+        # in some order.
+        mock_logger.error.assert_not_called()
+        mock_logger.exception.assert_called_once()
+        (exc_log_msg,) = mock_logger.exception.call_args.args
+        assert f"Error consuming event from Kafka: {repr(exception)} in context" in exc_log_msg
+        assert "full_topic='local-some-topic'" in exc_log_msg
+        assert "consumer_group='test_group_id'" in exc_log_msg
+        assert ("expected_signal=<OpenEdxPublicSignal: "
+                "org.openedx.learning.auth.session.login.completed.v1>") in exc_log_msg
+        if has_message:
+            assert "-- event details" in exc_log_msg
+        else:
+            assert "-- no event available" in exc_log_msg
+
+        expected_custom_attribute_calls = [
+            call("kafka_topic", "local-some-topic"),
+        ]
+        if has_message:
+            expected_custom_attribute_calls += [
+                call("kafka_message_id", "1111-1111"),
+                call("kafka_event_type", "org.openedx.learning.auth.session.login.completed.v1"),
+            ]
+        if has_kafka_error:
+            expected_custom_attribute_calls += [
+                call('kafka_error_fatal', is_fatal),
+                call('kafka_error_retriable', True),
+            ]
+        mock_set_custom_attribute.assert_has_calls(expected_custom_attribute_calls, any_order=True)
+
+        # For non-fatal errors, "no-event" sleep branch was triggered
+        if not is_fatal:
+            mock_sleep.assert_called_once_with(1)
+
+        mock_consumer.commit.assert_not_called()
+
+    def test_check_event_error(self):
+        """
+        DeserializingConsumer.poll() should never return a Message with an error() object,
+        but we check it anyway as a safeguard. This test exercises that branch.
+        """
+        with pytest.raises(Exception) as exc_info:
+            self.event_consumer.emit_signals_from_message(
+                FakeMessage(
+                    partition=2,
+                    error=KafkaError(123, "done broke"),
+                )
+            )
+
+        assert exc_info.value.args == (
+            "Polled message had error object (shouldn't happen): "
+            "KafkaError{code=ERR_123?,val=123,str=\"done broke\"}",
+        )
+
+    @override_settings(
+        EVENT_BUS_TOPIC_PREFIX='local',
+    )
+    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @ddt.data(True, False)
+    def test_emit_success(self, audit_logging, mock_logger, mock_set_attribute):
+        self.signal.disconnect(fake_receiver_raises_error)  # just successes for this one!
+
+        with override_settings(EVENT_BUS_KAFKA_AUDIT_LOGGING_ENABLED=audit_logging):
+            self.event_consumer.emit_signals_from_message(self.normal_message)
+        self.assert_signal_sent_with(self.signal, self.normal_event_data)
+        # Specifically, not called with 'kafka_logging_error'
+        mock_set_attribute.assert_not_called()
+        if audit_logging:
+            mock_logger.info.assert_has_calls([
+                call(
+                    "Message received from Kafka: topic=local-some-topic, partition=2, "
+                    f"offset=12345, message_id={self.message_id}, "
+                    "key=b'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob', event_timestamp_ms=1675114920123"
+                ),
+                call('Message from Kafka processed successfully'),
+            ])
+        else:
+            mock_logger.info.assert_not_called()
+
+    @override_settings(
+        EVENT_BUS_TOPIC_PREFIX='local',
+    )
+    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    def test_emit_success_tolerates_missing_timestamp(self, mock_logger, mock_set_attribute):
+        self.signal.disconnect(fake_receiver_raises_error)  # just successes for this one!
+        self.normal_message._timestamp = (TIMESTAMP_NOT_AVAILABLE, None)  # pylint: disable=protected-access
+
+        self.event_consumer.emit_signals_from_message(self.normal_message)
+        self.assert_signal_sent_with(self.signal, self.normal_event_data)
+        # Specifically, not called with 'kafka_logging_error'
+        mock_set_attribute.assert_not_called()
+        mock_logger.info.assert_has_calls([
+            call(
+                "Message received from Kafka: topic=local-some-topic, partition=2, "
+                f"offset=12345, message_id={self.message_id}, "
+                "key=b'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob', event_timestamp_ms=none"
+            ),
+            call('Message from Kafka processed successfully'),
+        ])
+
+    @patch('django.dispatch.dispatcher.logger', autospec=True)
+    def test_emit(self, mock_logger):
+        with pytest.raises(ReceiverError) as exc_info:
+            self.event_consumer.emit_signals_from_message(self.normal_message)
+        self.assert_signal_sent_with(self.signal, self.normal_event_data)
+        assert exc_info.value.args == (
+            "1 receiver(s) out of 3 produced errors (stack trace elsewhere in logs) "
+            "when handling signal <OpenEdxPublicSignal: "
+            "org.openedx.learning.auth.session.login.completed.v1>: "
+            "edx_event_bus_kafka.internal.tests.test_consumer.fake_receiver_raises_error="
+            "Exception('receiver whoops')",
+        )
+
+        # Check that django dispatch is logging the stack trace. Really, we only care that
+        # *something* does it, though. This test just ensures that our "(stack trace
+        # elsewhere in logs)" isn't a lie.
+        (receiver_error,) = exc_info.value.causes
+        mock_logger.error.assert_called_once_with(
+            "Error calling %s in Signal.send_robust() (%s)",
+            'fake_receiver_raises_error',
+            receiver_error,
+            exc_info=receiver_error,
+        )
+
+    def test_malformed_receiver_errors(self):
+        """
+        Ensure that even a really messed-up receiver is still reported correctly.
+        """
+        with pytest.raises(ReceiverError) as exc_info:
+            self.event_consumer._check_receiver_results([  # pylint: disable=protected-access
+                (lambda x:x, Exception("for lambda")),
+                # This would actually raise an error inside send_robust(), but it will serve well enough for testing...
+                ("not even a function", Exception("just plain bad")),
+            ])
+        assert exc_info.value.args == (
+            "2 receiver(s) out of 2 produced errors (stack trace elsewhere in logs) "
+            "when handling signal <OpenEdxPublicSignal: "
+            "org.openedx.learning.auth.session.login.completed.v1>: "
+
+            "edx_event_bus_kafka.internal.tests.test_consumer.TestEmitSignals."
+            "test_malformed_receiver_errors.<locals>.<lambda>=Exception('for lambda'), "
+
+            "not even a function=Exception('just plain bad')",
+        )
+
+    def test_no_type(self):
+        msg = copy.copy(self.normal_message)
+        msg._headers = []  # pylint: disable=protected-access
+
+        with pytest.raises(UnusableMessageError) as excinfo:
+            self.event_consumer.emit_signals_from_message(msg)
+
+        assert excinfo.value.args == (
+            "Missing ce_type header on message, cannot determine signal",
+        )
+        assert not self.mock_receiver.called
+
+    def test_multiple_types(self):
+        """
+        Very unlikely case, but this gets us coverage.
+        """
+        msg = copy.copy(self.normal_message)
+        msg._headers = [['ce_type', b'abc'], ['ce_type', b'def']]  # pylint: disable=protected-access
+
+        with pytest.raises(UnusableMessageError) as excinfo:
+            self.event_consumer.emit_signals_from_message(msg)
+
+        assert excinfo.value.args == (
+            "Multiple ce_type headers found on message, cannot determine signal",
+        )
+        assert not self.mock_receiver.called
+
+    def test_unexpected_signal_type_in_header(self):
+        msg = copy.copy(self.normal_message)
+        msg._headers = [  # pylint: disable=protected-access
+            ['ce_type', b'xxxx']
+        ]
+        with pytest.raises(UnusableMessageError) as excinfo:
+            self.event_consumer.emit_signals_from_message(msg)
+
+        assert excinfo.value.args == (
+            "Signal types do not match. Expected org.openedx.learning.auth.session.login.completed.v1. "
+            "Received message of type xxxx.",
+        )
+        assert not self.mock_receiver.called
+
+    def test_no_commit_if_no_error_logged(self):
+        """
+        Check that if there is an error that we fail to log, we do not commit the offset
+        """
+        def raise_exception(*args, **kwargs):
+            raise Exception("something broke")
+
+        with patch.object(self.event_consumer, 'emit_signals_from_message', side_effect=raise_exception):
+            with patch.object(self.event_consumer, 'record_event_consuming_error', side_effect=raise_exception):
+                with pytest.raises(Exception):
+                    mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
+                    self.event_consumer.consumer = mock_consumer
+                    self.event_consumer.consume_indefinitely()
+
+        mock_consumer.commit.assert_not_called()
+
+    def test_bad_headers(self):
+        """
+        Check that if we cannot process the message headers, we raise an UnusableMessageError
+
+        The various kinds of bad headers are more fully tested in test_utils
+        """
+        self.normal_message._headers = [  # pylint: disable=protected-access
+            ('ce_type', b'org.openedx.learning.auth.session.login.completed.v1'),
+            ('ce_id', b'bad_id')
+        ]
+        with pytest.raises(UnusableMessageError) as excinfo:
+            self.event_consumer.emit_signals_from_message(self.normal_message)
+
+        assert excinfo.value.args == (
+            "Error determining metadata from message headers: badly formed hexadecimal UUID string",
+        )
+
+        assert not self.mock_receiver.called
+
+
+class TestCommand(TestCase):
+    """
+    Tests for the consume_events management command
+    """
+
+    @override_settings(EVENT_BUS_KAFKA_CONSUMERS_ENABLED=False)
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
+    def test_kafka_consumers_disabled(self, mock_create_consumer, mock_logger):
+        call_command(Command(), topic='test', group_id='test', signal='')
+        assert not mock_create_consumer.called
+        mock_logger.error.assert_called_once_with("Kafka consumers not enabled, exiting.")
+
+    @patch.dict('edx_event_bus_kafka.internal.consumer.__dict__', {'confluent_kafka': None})
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
+    def test_kafka_consumers_no_lib(self, mock_create_consumer, mock_logger):
+        call_command(Command(), topic='test', group_id='test', signal='')
+        assert not mock_create_consumer.called
+        mock_logger.error.assert_called_once_with(
+            "Cannot consume events because confluent_kafka dependency (or one of its extras) was not installed"
+        )
+
+    @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.consume_indefinitely')
+    def test_kafka_consumers_normal(self, mock_consume, mock_create_consumer, _gsbt):
+        call_command(
+            Command(),
+            topic='test',
+            group_id='test',
+            signal='openedx',
+        )
+        assert mock_create_consumer.called
+        assert mock_consume.called
+
+    @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.reset_offsets_and_sleep_indefinitely')
+    def test_kafka_consumers_with_timestamp(self, mock_reset_offsets, mock_create_consumer, _gsbt):
+        call_command(
+            Command(),
+            topic='test',
+            group_id='test',
+            signal='openedx',
+            offset_time=['2019-05-18T15:17:08.132263']
+        )
+        assert mock_create_consumer.called
+        assert mock_reset_offsets.called
+
+    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
+    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.consume_indefinitely')
+    def test_kafka_consumers_with_bad_timestamp(self, _ci, _cc, _gsbt, mock_logger):
+        call_command(Command(), topic='test', group_id='test', signal='openedx', offset_time=['notatimestamp'])
+        mock_logger.exception.assert_any_call("Could not parse the offset timestamp.")
+        mock_logger.exception.assert_called_with("Error consuming Kafka events")

--- a/edx_event_bus_redis/internal/tests/test_consumer.py
+++ b/edx_event_bus_redis/internal/tests/test_consumer.py
@@ -115,7 +115,7 @@ class TestEmitSignals(TestCase):
         with override_settings(EVENT_BUS_REDIS_AUDIT_LOGGING_ENABLED=audit_logging):
             self.event_consumer.emit_signals_from_message(self.normal_message)
         self.assert_signal_sent_with(self.signal, self.normal_event_data)
-        # Specifically, not called with 'kafka_logging_error'
+        # Specifically, not called with 'redis_logging_error'
         mock_set_attribute.assert_not_called()
         if audit_logging:
             mock_logger.info.assert_has_calls([
@@ -140,7 +140,7 @@ class TestEmitSignals(TestCase):
 
         self.event_consumer.emit_signals_from_message(self.normal_message)
         self.assert_signal_sent_with(self.signal, self.normal_event_data)
-        # Specifically, not called with 'kafka_logging_error'
+        # Specifically, not called with 'redis_logging_error'
         mock_set_attribute.assert_not_called()
         mock_logger.info.assert_has_calls([
             call(

--- a/edx_event_bus_redis/internal/tests/test_consumer.py
+++ b/edx_event_bus_redis/internal/tests/test_consumer.py
@@ -14,16 +14,17 @@ from django.test.utils import override_settings
 from openedx_events.learning.data import UserData, UserPersonalData
 from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
 
-from edx_event_bus_redis.internal.consumer import RedisEventConsumer, ReceiverError, UnusableMessageError
+from edx_event_bus_redis.internal.consumer import ReceiverError, RedisEventConsumer, UnusableMessageError
 from edx_event_bus_redis.internal.tests.test_utils import FakeMessage
 from edx_event_bus_redis.management.commands.consume_events import Command
+
 
 def fake_receiver_returns_quietly(**kwargs):
     return
 
 
 def fake_receiver_raises_error(**kwargs):
-    raise Exception("receiver whoops")
+    raise Exception("receiver whoops")  # pylint: disable=broad-exception-raised
 
 
 @override_settings(

--- a/edx_event_bus_redis/internal/tests/test_consumer.py
+++ b/edx_event_bus_redis/internal/tests/test_consumer.py
@@ -3,7 +3,6 @@ Tests for event_consumer module.
 """
 
 import copy
-from datetime import datetime
 from unittest.mock import Mock, call, patch
 from uuid import uuid1
 
@@ -15,23 +14,9 @@ from django.test.utils import override_settings
 from openedx_events.learning.data import UserData, UserPersonalData
 from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
 
-from edx_event_bus_kafka.internal.consumer import KafkaEventConsumer, ReceiverError, UnusableMessageError
-from edx_event_bus_kafka.internal.tests.test_utils import FakeMessage, side_effects
-from edx_event_bus_kafka.management.commands.consume_events import Command
-
-# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
-try:
-    from confluent_kafka import (
-        TIMESTAMP_CREATE_TIME,
-        TIMESTAMP_NOT_AVAILABLE,
-        KafkaError,
-        KafkaException,
-        TopicPartition,
-    )
-    from confluent_kafka.error import ConsumeError
-except ImportError as e:  # pragma: no cover
-    pass
-
+from edx_event_bus_redis.internal.consumer import RedisEventConsumer, ReceiverError, UnusableMessageError
+from edx_event_bus_redis.internal.tests.test_utils import FakeMessage
+from edx_event_bus_redis.management.commands.consume_events import Command
 
 def fake_receiver_returns_quietly(**kwargs):
     return
@@ -42,10 +27,7 @@ def fake_receiver_raises_error(**kwargs):
 
 
 @override_settings(
-    EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='https://test-url',
-    EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='bootstrap-servers',
-    EVENT_BUS_KAFKA_API_KEY='test-key',
-    EVENT_BUS_KAFKA_API_SECRET='test-secret',
+    EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@locahost:6379/0',
 )
 @ddt.ddt
 class TestEmitSignals(TestCase):
@@ -73,23 +55,21 @@ class TestEmitSignals(TestCase):
         self.signal_type = self.signal_type_bytes.decode('utf-8')
         self.normal_message = FakeMessage(
             topic='local-some-topic',
-            partition=2,
-            offset=12345,
             headers=[
-                ('ce_id', self.message_id_bytes),
-                ('ce_type', self.signal_type_bytes),
+                ('id', self.message_id_bytes),
+                ('type', self.signal_type_bytes),
             ],
             key=b'\x00\x00\x00\x00\x01\x0cfoobob',  # Avro, as observed in manual test
             value=self.normal_event_data,
             error=None,
-            timestamp=(TIMESTAMP_CREATE_TIME, 1675114920123),
+            timestamp=1675114920123,
         )
         self.mock_receiver = Mock()
         self.signal = SESSION_LOGIN_COMPLETED
         self.signal.connect(fake_receiver_returns_quietly)
         self.signal.connect(fake_receiver_raises_error)
         self.signal.connect(self.mock_receiver)
-        self.event_consumer = KafkaEventConsumer('some-topic', 'test_group_id', self.signal)
+        self.event_consumer = RedisEventConsumer('some-topic', 'test_group_id', self.signal)
 
     def tearDown(self):
         self.signal.disconnect(fake_receiver_returns_quietly)
@@ -116,325 +96,22 @@ class TestEmitSignals(TestCase):
         assert metadata.event_type == signal.event_type
         assert metadata.sourcehost is not None
 
-    @override_settings(EVENT_BUS_KAFKA_CONSUMERS_ENABLED=False)
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @override_settings(EVENT_BUS_REDIS_CONSUMERS_ENABLED=False)
+    @patch('edx_event_bus_redis.internal.consumer.logger', autospec=True)
     def test_consume_loop_disabled(self, mock_logger):
         self.event_consumer.consume_indefinitely()  # returns at all
-        mock_logger.error.assert_called_once_with("Kafka consumers not enabled, exiting.")
-
-    def test_reset_offsets_and_sleep_indefinitely(self):
-        test_time = datetime.now()
-        self.event_consumer.consumer = Mock()
-        self.event_consumer._shut_down()  # pylint: disable=protected-access
-        self.event_consumer.reset_offsets_and_sleep_indefinitely(offset_timestamp=test_time)
-        reset_offsets = self.event_consumer.consumer.subscribe.call_args[1]['on_assign']
-        partitions = [TopicPartition('dummy_topic', 0, 0), TopicPartition('dummy_topic', 1, 0)]
-        self.event_consumer.consumer.offsets_for_times.return_value = partitions
-
-        # This is usually called by Kafka after assignment of partitions. For testing, we are calling
-        # it directly.
-        reset_offsets(self.event_consumer.consumer, partitions)
-
-        test_time_ms = int(test_time.timestamp()*1000)
-
-        # TopicPartition objects are considered equal if the topic and partition are equal, regardless of offset
-        # so we need to compare the objects by property
-        [partition_0, partition_1] = self.event_consumer.consumer.offsets_for_times.call_args.args[0]
-        assert partition_0.offset == test_time_ms
-        assert partition_0.topic == 'dummy_topic'
-        assert partition_0.partition == 0
-
-        assert partition_1.offset == test_time_ms
-        assert partition_1.topic == 'dummy_topic'
-        assert partition_1.partition == 1
-
-    @override_settings(
-        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-        EVENT_BUS_TOPIC_PREFIX='local',
-    )
-    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.time.sleep', autospec=True)
-    def test_consume_loop(self, mock_sleep, mock_logger, mock_set_custom_attribute):
-        """
-        Check the basic loop lifecycle.
-        """
-        def raise_exception():
-            raise Exception("something broke")
-
-        # How the emit_signals_from_message() mock will behave on each successive call.
-        mock_emit_side_effects = [
-            lambda: None,  # accept and ignore a message
-            raise_exception,
-            lambda: None,  # accept another message (exception didn't break loop)
-
-            # Final "call" just serves to stop the loop
-            self.event_consumer._shut_down  # pylint: disable=protected-access
-        ]
-
-        with patch.object(
-                self.event_consumer, 'emit_signals_from_message',
-                side_effect=side_effects(mock_emit_side_effects),
-        ) as mock_emit:
-            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
-            self.event_consumer.consumer = mock_consumer
-            self.event_consumer.consume_indefinitely()
-
-        # Check that each of the mocked out methods got called as expected.
-        mock_consumer.subscribe.assert_called_once_with(['local-some-topic'])
-        # Check that emit was called the expected number of times
-        assert mock_emit.call_args_list == [call(self.normal_message)] * len(mock_emit_side_effects)
-
-        # Check that there was one error log message and that it contained all the right parts,
-        # in some order.
-        mock_logger.exception.assert_called_once()
-        (exc_log_msg,) = mock_logger.exception.call_args.args
-        assert "Error consuming event from Kafka: Exception('something broke') in context" in exc_log_msg
-        assert "full_topic='local-some-topic'" in exc_log_msg
-        assert "consumer_group='test_group_id'" in exc_log_msg
-        assert ("expected_signal=<OpenEdxPublicSignal: "
-                "org.openedx.learning.auth.session.login.completed.v1>") in exc_log_msg
-        assert "-- event details: " in exc_log_msg
-        assert "'partition': 2" in exc_log_msg
-        assert "'offset': 12345" in exc_log_msg
-        assert f"'headers': [('ce_id', b'{self.message_id}'), " \
-               "('ce_type', b'org.openedx.learning.auth.session.login.completed.v1')]" in exc_log_msg
-        assert "'key': b'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob'" in exc_log_msg
-        assert "email='bob@foo.example'" in exc_log_msg
-
-        mock_set_custom_attribute.assert_has_calls(
-            [
-                call("kafka_topic", "local-some-topic"),
-                call("kafka_message_id", str(self.message_id)),
-                call("kafka_partition", 2),
-                call("kafka_offset", 12345),
-                call("kafka_event_type", "org.openedx.learning.auth.session.login.completed.v1"),
-            ] * len(mock_emit_side_effects),
-            any_order=True,
-        )
-
-        # Check that each message got committed (including the errored ones)
-        assert len(mock_consumer.commit.call_args_list) == len(mock_emit_side_effects)
-
-        mock_sleep.assert_not_called()
-        mock_consumer.close.assert_called_once_with()  # since shutdown was requested, not because of exception
-
-    @override_settings(
-        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-        EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT=4,
-    )
-    def test_consecutive_error_limit(self):
-        """Confirm that consecutive errors can break out of loop."""
-        def raise_exception():
-            raise Exception("something broke")
-
-        exception_count = 4
-
-        with patch.object(
-                self.event_consumer, 'emit_signals_from_message',
-                side_effect=side_effects([raise_exception] * exception_count)
-        ) as mock_emit:
-            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
-            self.event_consumer.consumer = mock_consumer
-            with pytest.raises(Exception) as exc_info:
-                self.event_consumer.consume_indefinitely()
-
-        assert mock_emit.call_args_list == [call(self.normal_message)] * exception_count
-        assert exc_info.value.args == ("Too many consecutive errors, exiting (4 in a row)",)
-
-    @override_settings(
-        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-    )
-    @patch('edx_event_bus_kafka.internal.consumer.connection')
-    @ddt.data(
-        (False, False, False),  # no connection, don't reconnect
-        (True, False, True),  # connection unusable, reconnect expected
-        (False, True, False),  # usable connection, no need to reconnect
-    )
-    @ddt.unpack
-    def test_connection_reset(self, has_connection, is_usable, reconnect_expected, mock_connection):
-        """Confirm we reconnect to the database as required"""
-        if not has_connection:
-            mock_connection.connection = None
-        mock_connection.is_usable.return_value = is_usable
-
-        with patch.object(
-                self.event_consumer, 'emit_signals_from_message',
-                side_effect=side_effects([self.event_consumer._shut_down])  # pylint: disable=protected-access
-        ):
-            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
-            self.event_consumer.consumer = mock_consumer
-            self.event_consumer.consume_indefinitely()
-
-        if reconnect_expected:
-            mock_connection.connect.assert_called_once()
-        else:
-            mock_connection.connect.assert_not_called()
-
-    @override_settings(
-        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-        EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT=4,
-    )
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.time.sleep', autospec=True)
-    def test_no_consume_with_offsets(self, mock_sleep, mock_logger):
-        mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
-        self.event_consumer.consumer = mock_consumer
-        mock_sleep.side_effect = side_effects([self.event_consumer._shut_down])  # pylint: disable=protected-access
-        self.event_consumer.consume_indefinitely(offset_timestamp=0)
-        mock_sleep.assert_called_with(30)
-        mock_logger.info.assert_any_call('Offsets are being reset. Sleeping instead of consuming events.')
-
-    @override_settings(
-        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-        EVENT_BUS_KAFKA_CONSUMER_CONSECUTIVE_ERRORS_LIMIT=4,
-    )
-    def test_non_consecutive_errors(self):
-        """Confirm that non-consecutive errors may not break out of loop."""
-        def raise_exception():
-            raise Exception("something broke")
-
-        mock_emit_side_effects = [
-            raise_exception, raise_exception,
-            lambda: None,  # an iteration that doesn't raise an exception
-            raise_exception, raise_exception,
-            # Stop the loop, since the non-consecutive exceptions won't do it
-            self.event_consumer._shut_down,  # pylint: disable=protected-access
-        ]
-
-        with patch.object(
-                self.event_consumer, 'emit_signals_from_message',
-                side_effect=side_effects(mock_emit_side_effects)
-        ) as mock_emit:
-            mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
-            self.event_consumer.consumer = mock_consumer
-            self.event_consumer.consume_indefinitely()  # exits normally
-
-        assert mock_emit.call_args_list == [call(self.normal_message)] * len(mock_emit_side_effects)
-
-    TEST_FAILED_MESSAGE = FakeMessage(
-        partition=7,
-        offset=6789,
-        headers=[
-            ('ce_id', b'1111-1111'),
-            ('ce_type', b'org.openedx.learning.auth.session.login.completed.v1'),
-        ],
-        key=b'\x00\x00\x00\x00\x01\x0cfoobob',  # Avro, as observed in manual test
-        value=b'XXX',
-    )
-    TEST_KAFKA_ERROR = KafkaError(2, fatal=False, retriable=True)
-    TEST_CONSUME_ERROR_NO_MESSAGE = ConsumeError(TEST_KAFKA_ERROR, exception=None, kafka_message=None)
-    TEST_CONSUME_ERROR_WITH_MESSAGE = ConsumeError(TEST_KAFKA_ERROR, exception=None, kafka_message=TEST_FAILED_MESSAGE)
-    TEST_KAFKA_EXCEPTION = KafkaException(TEST_KAFKA_ERROR)
-    TEST_KAFKA_FATAL_ERROR = KafkaError(2, fatal=True, retriable=True)
-    TEST_CONSUME_ERROR_FATAL = ConsumeError(TEST_KAFKA_FATAL_ERROR, exception=None, kafka_message=None)
-
-    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.time.sleep', autospec=True)
-    @override_settings(
-        EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-        EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-        EVENT_BUS_TOPIC_PREFIX='local',
-        EVENT_BUS_KAFKA_CONSUMER_POLL_FAILURE_SLEEP=1
-    )
-    @ddt.data(
-        (Exception("something random"), False, False, False),
-        (TEST_CONSUME_ERROR_NO_MESSAGE, False, True, False),
-        (TEST_CONSUME_ERROR_WITH_MESSAGE, True, True, False),
-        (TEST_KAFKA_EXCEPTION, False, True, False),
-        (TEST_CONSUME_ERROR_FATAL, False, True, True),
-    )
-    @ddt.unpack
-    def test_record_error_for_various_errors(
-        self, exception, has_message, has_kafka_error, is_fatal, mock_sleep, mock_logger, mock_set_custom_attribute,
-    ):
-        """
-        Covers reporting of an error in the consumer loop for various types of errors.
-        """
-        def poll_side_effect(*args, **kwargs):
-            # Only run one iteration
-            self.event_consumer._shut_down()  # pylint: disable=protected-access
-            raise exception
-
-        mock_consumer = Mock(**{'poll.side_effect': poll_side_effect}, autospec=True)
-        self.event_consumer.consumer = mock_consumer
-        if is_fatal:
-            with pytest.raises(ConsumeError) as exc_info:
-                self.event_consumer.consume_indefinitely()
-            assert exc_info.value == exception
-        else:
-            self.event_consumer.consume_indefinitely()
-
-        # Check that there was one exception log message and that it contained all the right parts,
-        # in some order.
-        mock_logger.error.assert_not_called()
-        mock_logger.exception.assert_called_once()
-        (exc_log_msg,) = mock_logger.exception.call_args.args
-        assert f"Error consuming event from Kafka: {repr(exception)} in context" in exc_log_msg
-        assert "full_topic='local-some-topic'" in exc_log_msg
-        assert "consumer_group='test_group_id'" in exc_log_msg
-        assert ("expected_signal=<OpenEdxPublicSignal: "
-                "org.openedx.learning.auth.session.login.completed.v1>") in exc_log_msg
-        if has_message:
-            assert "-- event details" in exc_log_msg
-        else:
-            assert "-- no event available" in exc_log_msg
-
-        expected_custom_attribute_calls = [
-            call("kafka_topic", "local-some-topic"),
-        ]
-        if has_message:
-            expected_custom_attribute_calls += [
-                call("kafka_message_id", "1111-1111"),
-                call("kafka_event_type", "org.openedx.learning.auth.session.login.completed.v1"),
-            ]
-        if has_kafka_error:
-            expected_custom_attribute_calls += [
-                call('kafka_error_fatal', is_fatal),
-                call('kafka_error_retriable', True),
-            ]
-        mock_set_custom_attribute.assert_has_calls(expected_custom_attribute_calls, any_order=True)
-
-        # For non-fatal errors, "no-event" sleep branch was triggered
-        if not is_fatal:
-            mock_sleep.assert_called_once_with(1)
-
-        mock_consumer.commit.assert_not_called()
-
-    def test_check_event_error(self):
-        """
-        DeserializingConsumer.poll() should never return a Message with an error() object,
-        but we check it anyway as a safeguard. This test exercises that branch.
-        """
-        with pytest.raises(Exception) as exc_info:
-            self.event_consumer.emit_signals_from_message(
-                FakeMessage(
-                    partition=2,
-                    error=KafkaError(123, "done broke"),
-                )
-            )
-
-        assert exc_info.value.args == (
-            "Polled message had error object (shouldn't happen): "
-            "KafkaError{code=ERR_123?,val=123,str=\"done broke\"}",
-        )
+        mock_logger.error.assert_called_once_with("Redis consumers not enabled, exiting.")
 
     @override_settings(
         EVENT_BUS_TOPIC_PREFIX='local',
     )
-    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_redis.internal.consumer.set_custom_attribute', autospec=True)
+    @patch('edx_event_bus_redis.internal.consumer.logger', autospec=True)
     @ddt.data(True, False)
     def test_emit_success(self, audit_logging, mock_logger, mock_set_attribute):
         self.signal.disconnect(fake_receiver_raises_error)  # just successes for this one!
 
-        with override_settings(EVENT_BUS_KAFKA_AUDIT_LOGGING_ENABLED=audit_logging):
+        with override_settings(EVENT_BUS_REDIS_AUDIT_LOGGING_ENABLED=audit_logging):
             self.event_consumer.emit_signals_from_message(self.normal_message)
         self.assert_signal_sent_with(self.signal, self.normal_event_data)
         # Specifically, not called with 'kafka_logging_error'
@@ -442,11 +119,11 @@ class TestEmitSignals(TestCase):
         if audit_logging:
             mock_logger.info.assert_has_calls([
                 call(
-                    "Message received from Kafka: topic=local-some-topic, partition=2, "
-                    f"offset=12345, message_id={self.message_id}, "
+                    "Message received from Redis: topic=local-some-topic, "
+                    f"message_id={self.message_id}, "
                     "key=b'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob', event_timestamp_ms=1675114920123"
                 ),
-                call('Message from Kafka processed successfully'),
+                call('Message from Redis processed successfully'),
             ])
         else:
             mock_logger.info.assert_not_called()
@@ -454,11 +131,11 @@ class TestEmitSignals(TestCase):
     @override_settings(
         EVENT_BUS_TOPIC_PREFIX='local',
     )
-    @patch('edx_event_bus_kafka.internal.consumer.set_custom_attribute', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_redis.internal.consumer.set_custom_attribute', autospec=True)
+    @patch('edx_event_bus_redis.internal.consumer.logger', autospec=True)
     def test_emit_success_tolerates_missing_timestamp(self, mock_logger, mock_set_attribute):
         self.signal.disconnect(fake_receiver_raises_error)  # just successes for this one!
-        self.normal_message._timestamp = (TIMESTAMP_NOT_AVAILABLE, None)  # pylint: disable=protected-access
+        self.normal_message._timestamp = None  # pylint: disable=protected-access
 
         self.event_consumer.emit_signals_from_message(self.normal_message)
         self.assert_signal_sent_with(self.signal, self.normal_event_data)
@@ -466,11 +143,11 @@ class TestEmitSignals(TestCase):
         mock_set_attribute.assert_not_called()
         mock_logger.info.assert_has_calls([
             call(
-                "Message received from Kafka: topic=local-some-topic, partition=2, "
-                f"offset=12345, message_id={self.message_id}, "
-                "key=b'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob', event_timestamp_ms=none"
+                "Message received from Redis: topic=local-some-topic, "
+                f"message_id={self.message_id}, "
+                "key=b'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob', event_timestamp_ms=None"
             ),
-            call('Message from Kafka processed successfully'),
+            call('Message from Redis processed successfully'),
         ])
 
     @patch('django.dispatch.dispatcher.logger', autospec=True)
@@ -482,7 +159,7 @@ class TestEmitSignals(TestCase):
             "1 receiver(s) out of 3 produced errors (stack trace elsewhere in logs) "
             "when handling signal <OpenEdxPublicSignal: "
             "org.openedx.learning.auth.session.login.completed.v1>: "
-            "edx_event_bus_kafka.internal.tests.test_consumer.fake_receiver_raises_error="
+            "edx_event_bus_redis.internal.tests.test_consumer.fake_receiver_raises_error="
             "Exception('receiver whoops')",
         )
 
@@ -512,7 +189,7 @@ class TestEmitSignals(TestCase):
             "when handling signal <OpenEdxPublicSignal: "
             "org.openedx.learning.auth.session.login.completed.v1>: "
 
-            "edx_event_bus_kafka.internal.tests.test_consumer.TestEmitSignals."
+            "edx_event_bus_redis.internal.tests.test_consumer.TestEmitSignals."
             "test_malformed_receiver_errors.<locals>.<lambda>=Exception('for lambda'), "
 
             "not even a function=Exception('just plain bad')",
@@ -526,7 +203,7 @@ class TestEmitSignals(TestCase):
             self.event_consumer.emit_signals_from_message(msg)
 
         assert excinfo.value.args == (
-            "Missing ce_type header on message, cannot determine signal",
+            "Missing type header on message, cannot determine signal",
         )
         assert not self.mock_receiver.called
 
@@ -535,20 +212,20 @@ class TestEmitSignals(TestCase):
         Very unlikely case, but this gets us coverage.
         """
         msg = copy.copy(self.normal_message)
-        msg._headers = [['ce_type', b'abc'], ['ce_type', b'def']]  # pylint: disable=protected-access
+        msg._headers = [['type', b'abc'], ['type', b'def']]  # pylint: disable=protected-access
 
         with pytest.raises(UnusableMessageError) as excinfo:
             self.event_consumer.emit_signals_from_message(msg)
 
         assert excinfo.value.args == (
-            "Multiple ce_type headers found on message, cannot determine signal",
+            "Multiple type headers found on message, cannot determine signal",
         )
         assert not self.mock_receiver.called
 
     def test_unexpected_signal_type_in_header(self):
         msg = copy.copy(self.normal_message)
         msg._headers = [  # pylint: disable=protected-access
-            ['ce_type', b'xxxx']
+            ['type', b'xxxx']
         ]
         with pytest.raises(UnusableMessageError) as excinfo:
             self.event_consumer.emit_signals_from_message(msg)
@@ -559,22 +236,6 @@ class TestEmitSignals(TestCase):
         )
         assert not self.mock_receiver.called
 
-    def test_no_commit_if_no_error_logged(self):
-        """
-        Check that if there is an error that we fail to log, we do not commit the offset
-        """
-        def raise_exception(*args, **kwargs):
-            raise Exception("something broke")
-
-        with patch.object(self.event_consumer, 'emit_signals_from_message', side_effect=raise_exception):
-            with patch.object(self.event_consumer, 'record_event_consuming_error', side_effect=raise_exception):
-                with pytest.raises(Exception):
-                    mock_consumer = Mock(**{'poll.return_value': self.normal_message}, autospec=True)
-                    self.event_consumer.consumer = mock_consumer
-                    self.event_consumer.consume_indefinitely()
-
-        mock_consumer.commit.assert_not_called()
-
     def test_bad_headers(self):
         """
         Check that if we cannot process the message headers, we raise an UnusableMessageError
@@ -582,8 +243,8 @@ class TestEmitSignals(TestCase):
         The various kinds of bad headers are more fully tested in test_utils
         """
         self.normal_message._headers = [  # pylint: disable=protected-access
-            ('ce_type', b'org.openedx.learning.auth.session.login.completed.v1'),
-            ('ce_id', b'bad_id')
+            ('type', b'org.openedx.learning.auth.session.login.completed.v1'),
+            ('id', b'bad_id')
         ]
         with pytest.raises(UnusableMessageError) as excinfo:
             self.event_consumer.emit_signals_from_message(self.normal_message)
@@ -600,28 +261,18 @@ class TestCommand(TestCase):
     Tests for the consume_events management command
     """
 
-    @override_settings(EVENT_BUS_KAFKA_CONSUMERS_ENABLED=False)
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
-    def test_kafka_consumers_disabled(self, mock_create_consumer, mock_logger):
+    @override_settings(EVENT_BUS_REDIS_CONSUMERS_ENABLED=False)
+    @patch('edx_event_bus_redis.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_redis.internal.consumer.RedisEventConsumer._create_consumer')
+    def test_redis_consumers_disabled(self, mock_create_consumer, mock_logger):
         call_command(Command(), topic='test', group_id='test', signal='')
         assert not mock_create_consumer.called
-        mock_logger.error.assert_called_once_with("Kafka consumers not enabled, exiting.")
+        mock_logger.error.assert_called_once_with("Redis consumers not enabled, exiting.")
 
-    @patch.dict('edx_event_bus_kafka.internal.consumer.__dict__', {'confluent_kafka': None})
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
-    def test_kafka_consumers_no_lib(self, mock_create_consumer, mock_logger):
-        call_command(Command(), topic='test', group_id='test', signal='')
-        assert not mock_create_consumer.called
-        mock_logger.error.assert_called_once_with(
-            "Cannot consume events because confluent_kafka dependency (or one of its extras) was not installed"
-        )
-
-    @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.consume_indefinitely')
-    def test_kafka_consumers_normal(self, mock_consume, mock_create_consumer, _gsbt):
+    @patch('edx_event_bus_redis.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
+    @patch('edx_event_bus_redis.internal.consumer.RedisEventConsumer._create_consumer')
+    @patch('edx_event_bus_redis.internal.consumer.RedisEventConsumer.consume_indefinitely')
+    def test_redis_consumers_normal(self, mock_consume, mock_create_consumer, _gsbt):
         call_command(
             Command(),
             topic='test',
@@ -631,10 +282,9 @@ class TestCommand(TestCase):
         assert mock_create_consumer.called
         assert mock_consume.called
 
-    @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.reset_offsets_and_sleep_indefinitely')
-    def test_kafka_consumers_with_timestamp(self, mock_reset_offsets, mock_create_consumer, _gsbt):
+    @patch('edx_event_bus_redis.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
+    @patch('edx_event_bus_redis.internal.consumer.RedisEventConsumer._create_consumer')
+    def test_redis_consumers_with_timestamp(self, mock_reset_offsets, mock_create_consumer):
         call_command(
             Command(),
             topic='test',
@@ -645,11 +295,11 @@ class TestCommand(TestCase):
         assert mock_create_consumer.called
         assert mock_reset_offsets.called
 
-    @patch('edx_event_bus_kafka.internal.consumer.logger', autospec=True)
-    @patch('edx_event_bus_kafka.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer._create_consumer')
-    @patch('edx_event_bus_kafka.internal.consumer.KafkaEventConsumer.consume_indefinitely')
-    def test_kafka_consumers_with_bad_timestamp(self, _ci, _cc, _gsbt, mock_logger):
+    @patch('edx_event_bus_redis.internal.consumer.logger', autospec=True)
+    @patch('edx_event_bus_redis.internal.consumer.OpenEdxPublicSignal.get_signal_by_type')
+    @patch('edx_event_bus_redis.internal.consumer.RedisEventConsumer._create_consumer')
+    @patch('edx_event_bus_redis.internal.consumer.RedisEventConsumer.consume_indefinitely')
+    def test_redis_consumers_with_bad_timestamp(self, _ci, _cc, _gsbt, mock_logger):
         call_command(Command(), topic='test', group_id='test', signal='openedx', offset_time=['notatimestamp'])
         mock_logger.exception.assert_any_call("Could not parse the offset timestamp.")
-        mock_logger.exception.assert_called_with("Error consuming Kafka events")
+        mock_logger.exception.assert_called_with("Error consuming Redis events")

--- a/edx_event_bus_redis/internal/tests/test_producer.py
+++ b/edx_event_bus_redis/internal/tests/test_producer.py
@@ -1,0 +1,392 @@
+"""
+Test the event producer code.
+"""
+
+import datetime
+import gc
+import time
+import warnings
+from unittest import TestCase
+from unittest.mock import ANY, Mock, call, patch
+
+import ddt
+import openedx_events.event_bus
+import openedx_events.learning.signals
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+from openedx_events.data import EventsMetadata
+from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
+from openedx_events.event_bus.avro.tests.test_utilities import SubTestData0, create_simple_signal
+from openedx_events.learning.data import UserData, UserPersonalData
+
+import edx_event_bus_kafka.internal.producer as ep
+from edx_event_bus_kafka.internal.tests.test_utils import FakeMessage
+from edx_event_bus_kafka.management.commands.produce_event import Command
+
+# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
+try:
+    from confluent_kafka.schema_registry.avro import AvroSerializer
+except ImportError:  # pragma: no cover
+    pass
+
+
+@ddt.ddt
+class TestEventProducer(TestCase):
+    """Test producer."""
+
+    def setUp(self):
+        super().setUp()
+        self.signal = openedx_events.learning.signals.SESSION_LOGIN_COMPLETED
+        self.event_data = {
+            'user': UserData(
+                id=123,
+                is_active=True,
+                pii=UserPersonalData(
+                    username='foobob',
+                    email='bob@foo.example',
+                    name="Bob Foo",
+                )
+            )
+        }
+
+    def test_extract_event_key(self):
+        assert ep.extract_event_key(self.event_data, 'user.pii.username') == 'foobob'
+        with pytest.raises(Exception,
+                           match="Could not extract key from event; lookup in xxx failed at 'xxx' in dictionary"):
+            ep.extract_event_key(self.event_data, 'xxx')
+        with pytest.raises(Exception,
+                           match="Could not extract key from event; lookup in user.xxx failed at 'xxx' in object"):
+            ep.extract_event_key(self.event_data, 'user.xxx')
+
+    def test_descend_avro_schema(self):
+        schema = AvroSignalSerializer(self.signal).schema
+
+        assert ep.descend_avro_schema(schema, ['user', 'pii', 'username']) == {"name": "username", "type": "string"}
+
+        with pytest.raises(Exception) as excinfo:
+            ep.descend_avro_schema(schema, ['user', 'xxx'])
+        assert excinfo.value.args == ("Error traversing Avro schema along path ['user', 'xxx']; failed at 'xxx'.",)
+        assert isinstance(excinfo.value.__cause__, IndexError)
+
+    def test_extract_key_schema(self):
+        schema = ep.extract_key_schema(AvroSignalSerializer(self.signal), 'user.pii.username')
+        assert schema == '{"name": "username", "type": "string"}'
+
+    def test_serializers_configured(self):
+        with override_settings(EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345'):
+            key_ser, value_ser = ep.get_serializers(self.signal, 'user.id')
+            # We can't actually call them because they want to talk to the schema server.
+            assert isinstance(key_ser, AvroSerializer)
+            assert isinstance(value_ser, AvroSerializer)
+
+    def test_serializers_unconfigured(self):
+        with pytest.raises(Exception, match="missing library or settings"):
+            ep.get_serializers(self.signal, 'user.id')
+
+    def test_create_producer_unconfigured(self):
+        """With missing essential settings, just warn and return None."""
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter('always')
+            assert ep.create_producer() is None
+            assert len(caught_warnings) == 1
+            assert str(caught_warnings[0].message).startswith("Cannot configure event-bus-kafka: Missing setting ")
+
+    def test_create_producer_configured(self):
+        """
+        Creation succeeds when all settings are present.
+
+        Also tests basic compliance with the implementation-loader API in openedx-events.
+        """
+        with override_settings(
+                EVENT_BUS_PRODUCER='edx_event_bus_kafka.create_producer',
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY='some_key',
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET='some_secret',
+                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+                # include these just to maximize code coverage
+                EVENT_BUS_KAFKA_API_KEY='some_other_key',
+                EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
+        ):
+            assert isinstance(openedx_events.event_bus.get_producer(), ep.KafkaEventProducer)
+
+    @patch('edx_event_bus_kafka.internal.producer.logger')
+    @ddt.data(True, False)
+    def test_on_event_deliver(self, audit_logging, mock_logger):
+        metadata = EventsMetadata(
+            event_type=self.signal.event_type,
+            time=datetime.datetime.now(datetime.timezone.utc),
+            sourcelib=(1, 2, 3),
+        )
+
+        context = ep.ProducingContext(
+            full_topic='some_topic',
+            event_key='foobob',
+            signal=self.signal,
+            initial_topic='bare_topic',
+            event_key_field='a.key.field',
+            event_data=self.event_data,
+            event_metadata=metadata,
+        )
+
+        fake_event = FakeMessage(
+            topic=context.full_topic, partition='some_partition', offset=12345,
+            key=b'\x00\x00\x00\x00\x01\x0cfoobob',
+        )
+
+        # ensure on_event_deliver reports the entire calling context if there was an error
+        context.on_event_deliver(Exception("problem!"), fake_event)
+
+        # extract the error message that was produced and check it has all relevant information (order isn't guaranteed
+        # and doesn't actually matter, nor do we want to worry if other information is added later)
+        (error_string,) = mock_logger.exception.call_args.args
+        assert "full_topic='some_topic'" in error_string
+        assert "error=problem!" in error_string
+
+        # Now check behavior with a delivered event
+        with patch.object(FakeMessage, 'headers') as mock_headers:
+            with override_settings(EVENT_BUS_KAFKA_AUDIT_LOGGING_ENABLED=audit_logging):
+                context.on_event_deliver(None, fake_event)
+
+        # We know that headers() is not implemented yet for the delivery
+        # callback, so fail early in unit tests if someone tries to use it.
+        # https://github.com/confluentinc/confluent-kafka-python/issues/574
+        mock_headers.assert_not_called()
+
+        if audit_logging:
+            mock_logger.info.assert_called_once_with(
+                'Message delivered to Kafka event bus: topic=some_topic, partition=some_partition, '
+                f'offset=12345, message_id={metadata.id}, key=b\'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob\''
+            )
+        else:
+            mock_logger.info.assert_not_called()
+
+    # Mock out the serializers for this one so we don't have to deal
+    # with expected Avro bytes -- and they can't call their schema server.
+    @patch(
+        'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
+        return_value=(
+            lambda _key, _ctx: b'key-bytes-here',
+            lambda _value, _ctx: b'value-bytes-here',
+        )
+    )
+    def test_send_to_event_bus(self, mock_get_serializers):
+        with override_settings(
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+                EVENT_BUS_TOPIC_PREFIX='prod',
+                SERVICE_VARIANT='test',
+        ):
+            now = datetime.datetime.now(datetime.timezone.utc)
+            metadata = EventsMetadata(event_type=self.signal.event_type,
+                                      time=now, sourcelib=(1, 2, 3))
+            producer_api = ep.create_producer()
+            with patch.object(producer_api, 'producer', autospec=True) as mock_producer:
+                producer_api.send(
+                    signal=self.signal, topic='user-stuff',
+                    event_key_field='user.id', event_data=self.event_data, event_metadata=metadata
+                )
+
+        mock_get_serializers.assert_called_once_with(self.signal, 'user.id')
+
+        expected_headers = {
+                'ce_type': b'org.openedx.learning.auth.session.login.completed.v1',
+                'ce_id': str(metadata.id).encode("utf8"),
+                'ce_source': b'openedx/test/web',
+                'sourcehost': metadata.sourcehost.encode("utf8"),
+                'ce_specversion': b'1.0',
+                'content-type': b'application/avro',
+                'ce_datacontenttype': b'application/avro',
+                'ce_time': now.isoformat().encode("utf8"),
+                'ce_minorversion': b'0',
+                'sourcelib': b'1.2.3',
+            }
+
+        mock_producer.produce.assert_called_once_with(
+            'prod-user-stuff', key=b'key-bytes-here', value=b'value-bytes-here', on_delivery=ANY,
+            headers=expected_headers,
+        )
+
+    @patch(
+        'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
+        return_value=(
+            lambda _key, _ctx: b'key-bytes-here',
+            lambda _value, _ctx: b'value-bytes-here',
+        )
+    )
+    @patch('edx_event_bus_kafka.internal.producer.logger')
+    def test_full_event_data_present_in_key_extraction_error(self, mock_logger, *args):
+        simple_signal = create_simple_signal({'test_data': SubTestData0})
+        with override_settings(
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+                EVENT_BUS_TOPIC_PREFIX='dev',
+                SERVICE_VARIANT='test',
+        ):
+            metadata = EventsMetadata(event_type=simple_signal.event_type, minorversion=0)
+            producer_api = ep.create_producer()
+            # force an exception with a bad event_key_field
+            producer_api.send(signal=simple_signal, topic='topic', event_key_field='bad_field',
+                              event_data={'test_data': SubTestData0(sub_name="name", course_id="id")},
+                              event_metadata=metadata)
+
+        (error_string,) = mock_logger.exception.call_args.args
+        assert "event_data={'test_data': SubTestData0(sub_name='name', course_id='id')}" in error_string
+        assert "signal=<OpenEdxPublicSignal: simple.signal>" in error_string
+        assert "initial_topic='topic'" in error_string
+        assert "full_topic='dev-topic'" in error_string
+        assert "event_key_field='bad_field'" in error_string
+        assert "event_type='simple.signal'" in error_string
+        assert "source='openedx/test/web'" in error_string
+        assert f"id=UUID('{metadata.id}')" in error_string
+        assert f"sourcehost='{metadata.sourcehost}'" in error_string
+
+    @patch(
+        'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
+        return_value=(
+            lambda _key, _ctx: b'key-bytes-here',
+            lambda _value, _ctx: b'value-bytes-here',
+        )
+    )
+    @patch('edx_event_bus_kafka.internal.producer.logger')
+    def test_full_event_data_present_in_kafka_error(self, mock_logger, *args):
+        simple_signal = create_simple_signal({'test_data': SubTestData0})
+        with override_settings(
+                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+                EVENT_BUS_TOPIC_PREFIX='dev',
+                SERVICE_VARIANT='test',
+        ):
+            producer_api = ep.create_producer()
+            metadata = EventsMetadata(event_type=simple_signal.event_type, minorversion=0)
+            with patch.object(producer_api, 'producer', autospec=True) as mock_producer:
+                # imitate a failed send to Kafka
+                mock_producer.produce = Mock(side_effect=Exception('bad!'))
+                producer_api.send(signal=simple_signal, topic='topic', event_key_field='test_data.course_id',
+                                  event_data={'test_data': SubTestData0(sub_name="name", course_id="ABCx")},
+                                  event_metadata=metadata)
+
+        (error_string,) = mock_logger.exception.call_args.args
+        assert "event_data={'test_data': SubTestData0(sub_name='name', course_id='ABCx')}" in error_string
+        assert "signal=<OpenEdxPublicSignal: simple.signal>" in error_string
+        assert "initial_topic='topic'" in error_string
+        assert "full_topic='dev-topic'" in error_string
+        assert "event_key_field='test_data.course_id'" in error_string
+        assert "source='openedx/test/web'" in error_string
+        assert f"id=UUID('{metadata.id}')" in error_string
+        assert f"sourcehost='{metadata.sourcehost}'" in error_string
+        # since we didn't fail until after key extraction we should have an event_key to report
+        assert "event_key='ABCx'" in error_string
+        assert "error=bad!" in error_string
+
+    @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)
+    def test_polling_loop_terminates(self):
+        """
+        Test that polling loop stops as soon as the producer is garbage-collected.
+        """
+        call_count = 0
+
+        def increment_call_count(*args):
+            nonlocal call_count
+            call_count += 1
+
+        mock_producer = Mock(**{'poll.side_effect': increment_call_count})
+        producer_api = ep.KafkaEventProducer(mock_producer)  # Created, starts polling
+
+        # Allow a little time to pass and check that the mock poll has been called
+        time.sleep(1.0)
+        assert call_count >= 3  # some small value; would actually be about 20
+        print(producer_api)  # Use the value here to ensure it isn't GC'd early
+
+        # Allow garbage collection of these objects, then ask for it to happen.
+        producer_api = None
+        mock_producer = None
+        gc.collect()
+
+        time.sleep(0.2)  # small multiple of loop iteration time
+        count_after_gc = call_count
+
+        # Wait a little longer and confirm that the count is no longer rising
+        time.sleep(1.0)
+        assert call_count == count_after_gc
+
+    @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)
+    def test_polling_loop_robust(self):
+        """
+        Test that polling loop continues even if one call raises an exception.
+        """
+        call_count = 0
+
+        def increment_call_count(*args):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("Exercise error handler on first iteration")
+
+        mock_producer = Mock(**{'poll.side_effect': increment_call_count})
+        producer_api = ep.KafkaEventProducer(mock_producer)  # Created, starts polling
+
+        # Allow a little time to pass and check that the mock poll has been called
+        time.sleep(1.0)
+        assert call_count >= 3  # some small value; would actually be about 20
+        print(producer_api)  # Use the value here to ensure it isn't GC'd early
+
+    @override_settings(EVENT_BUS_TOPIC_PREFIX='stage')
+    @override_settings(EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345')
+    @override_settings(EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321')
+    @patch('edx_event_bus_kafka.internal.producer.SerializationContext')
+    def test_serialize_and_produce_to_same_topic(self, mock_context):
+        producer_api = ep.create_producer()
+        with patch('edx_event_bus_kafka.internal.producer.AvroSerializer',
+                   return_value=lambda _x, _y: b'bytes-here'):
+            with patch.object(producer_api, 'producer', autospec=True) as mock_producer:
+                producer_api.send(
+                    signal=self.signal, topic='user-stuff',
+                    event_key_field='user.id', event_data=self.event_data,
+                    event_metadata=EventsMetadata(event_type=self.signal.event_type, minorversion=0)
+                )
+
+        mock_context.assert_has_calls([
+            call('stage-user-stuff', 'key', ANY),
+            call('stage-user-stuff', 'value', ANY),
+        ])
+        assert mock_context.call_count == 2
+        mock_producer.produce.assert_called_once_with(
+            'stage-user-stuff', key=b'bytes-here', value=b'bytes-here',
+            on_delivery=ANY,
+            # headers are tested elsewhere, we just want to verify the topics
+            headers=ANY,
+        )
+
+
+class TestCommand(TestCase):
+    """
+    Test produce_event management command
+    """
+    @override_settings(
+      EVENT_BUS_TOPIC_PREFIX='dev',
+      EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
+      EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
+    )
+    @patch('edx_event_bus_kafka.management.commands.produce_event.logger')
+    @patch('edx_event_bus_kafka.internal.producer.SerializationContext')
+    def test_command(self, _, fake_logger):
+        producer_api = ep.create_producer()
+        mocked_producer = Mock(autospec=True)
+        producer_api.producer = mocked_producer
+
+        with patch('edx_event_bus_kafka.management.commands.produce_event.create_producer') as mock_create_producer:
+            with patch('edx_event_bus_kafka.internal.producer.AvroSerializer',
+                       return_value=lambda _x, _y: b'bytes-here'):
+                mock_create_producer.return_value = producer_api
+                call_command(Command(),
+                             topic=['test'],
+                             signal=['openedx_events.learning.signals.SESSION_LOGIN_COMPLETED'],
+                             data=['{"user": {"id": 123, "is_active": true,'
+                                   ' "pii":{"username": "foobob", "email": "bob@foo.example", "name": "Bob Foo"}}}'],
+                             key_field=['user.pii.username'],
+                             )
+        # Actual event producing is tested elsewhere, this is just to make sure the command produces *something*
+        mocked_producer.produce.assert_called_once_with('dev-test', key=b'bytes-here', value=b'bytes-here',
+                                                        on_delivery=ANY, headers=ANY,)
+        fake_logger.exception.assert_not_called()

--- a/edx_event_bus_redis/internal/tests/test_producer.py
+++ b/edx_event_bus_redis/internal/tests/test_producer.py
@@ -2,33 +2,16 @@
 Test the event producer code.
 """
 
-import datetime
-import gc
-import time
 import warnings
 from unittest import TestCase
-from unittest.mock import ANY, Mock, call, patch
 
 import ddt
 import openedx_events.event_bus
 import openedx_events.learning.signals
-import pytest
-from django.core.management import call_command
 from django.test import override_settings
-from openedx_events.data import EventsMetadata
-from openedx_events.event_bus.avro.serializer import AvroSignalSerializer
-from openedx_events.event_bus.avro.tests.test_utilities import SubTestData0, create_simple_signal
 from openedx_events.learning.data import UserData, UserPersonalData
 
-import edx_event_bus_kafka.internal.producer as ep
-from edx_event_bus_kafka.internal.tests.test_utils import FakeMessage
-from edx_event_bus_kafka.management.commands.produce_event import Command
-
-# See https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0005-optional-import-of-confluent-kafka.rst
-try:
-    from confluent_kafka.schema_registry.avro import AvroSerializer
-except ImportError:  # pragma: no cover
-    pass
+import edx_event_bus_redis.internal.producer as ep
 
 
 @ddt.ddt
@@ -50,47 +33,13 @@ class TestEventProducer(TestCase):
             )
         }
 
-    def test_extract_event_key(self):
-        assert ep.extract_event_key(self.event_data, 'user.pii.username') == 'foobob'
-        with pytest.raises(Exception,
-                           match="Could not extract key from event; lookup in xxx failed at 'xxx' in dictionary"):
-            ep.extract_event_key(self.event_data, 'xxx')
-        with pytest.raises(Exception,
-                           match="Could not extract key from event; lookup in user.xxx failed at 'xxx' in object"):
-            ep.extract_event_key(self.event_data, 'user.xxx')
-
-    def test_descend_avro_schema(self):
-        schema = AvroSignalSerializer(self.signal).schema
-
-        assert ep.descend_avro_schema(schema, ['user', 'pii', 'username']) == {"name": "username", "type": "string"}
-
-        with pytest.raises(Exception) as excinfo:
-            ep.descend_avro_schema(schema, ['user', 'xxx'])
-        assert excinfo.value.args == ("Error traversing Avro schema along path ['user', 'xxx']; failed at 'xxx'.",)
-        assert isinstance(excinfo.value.__cause__, IndexError)
-
-    def test_extract_key_schema(self):
-        schema = ep.extract_key_schema(AvroSignalSerializer(self.signal), 'user.pii.username')
-        assert schema == '{"name": "username", "type": "string"}'
-
-    def test_serializers_configured(self):
-        with override_settings(EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345'):
-            key_ser, value_ser = ep.get_serializers(self.signal, 'user.id')
-            # We can't actually call them because they want to talk to the schema server.
-            assert isinstance(key_ser, AvroSerializer)
-            assert isinstance(value_ser, AvroSerializer)
-
-    def test_serializers_unconfigured(self):
-        with pytest.raises(Exception, match="missing library or settings"):
-            ep.get_serializers(self.signal, 'user.id')
-
     def test_create_producer_unconfigured(self):
         """With missing essential settings, just warn and return None."""
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter('always')
             assert ep.create_producer() is None
             assert len(caught_warnings) == 1
-            assert str(caught_warnings[0].message).startswith("Cannot configure event-bus-kafka: Missing setting ")
+            assert str(caught_warnings[0].message).startswith("Cannot configure event-bus-redis: Missing setting ")
 
     def test_create_producer_configured(self):
         """
@@ -99,294 +48,7 @@ class TestEventProducer(TestCase):
         Also tests basic compliance with the implementation-loader API in openedx-events.
         """
         with override_settings(
-                EVENT_BUS_PRODUCER='edx_event_bus_kafka.create_producer',
-                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_KEY='some_key',
-                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_API_SECRET='some_secret',
-                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-                # include these just to maximize code coverage
-                EVENT_BUS_KAFKA_API_KEY='some_other_key',
-                EVENT_BUS_KAFKA_API_SECRET='some_other_secret',
+                EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer',
+                EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@locahost:6379/0'
         ):
-            assert isinstance(openedx_events.event_bus.get_producer(), ep.KafkaEventProducer)
-
-    @patch('edx_event_bus_kafka.internal.producer.logger')
-    @ddt.data(True, False)
-    def test_on_event_deliver(self, audit_logging, mock_logger):
-        metadata = EventsMetadata(
-            event_type=self.signal.event_type,
-            time=datetime.datetime.now(datetime.timezone.utc),
-            sourcelib=(1, 2, 3),
-        )
-
-        context = ep.ProducingContext(
-            full_topic='some_topic',
-            event_key='foobob',
-            signal=self.signal,
-            initial_topic='bare_topic',
-            event_key_field='a.key.field',
-            event_data=self.event_data,
-            event_metadata=metadata,
-        )
-
-        fake_event = FakeMessage(
-            topic=context.full_topic, partition='some_partition', offset=12345,
-            key=b'\x00\x00\x00\x00\x01\x0cfoobob',
-        )
-
-        # ensure on_event_deliver reports the entire calling context if there was an error
-        context.on_event_deliver(Exception("problem!"), fake_event)
-
-        # extract the error message that was produced and check it has all relevant information (order isn't guaranteed
-        # and doesn't actually matter, nor do we want to worry if other information is added later)
-        (error_string,) = mock_logger.exception.call_args.args
-        assert "full_topic='some_topic'" in error_string
-        assert "error=problem!" in error_string
-
-        # Now check behavior with a delivered event
-        with patch.object(FakeMessage, 'headers') as mock_headers:
-            with override_settings(EVENT_BUS_KAFKA_AUDIT_LOGGING_ENABLED=audit_logging):
-                context.on_event_deliver(None, fake_event)
-
-        # We know that headers() is not implemented yet for the delivery
-        # callback, so fail early in unit tests if someone tries to use it.
-        # https://github.com/confluentinc/confluent-kafka-python/issues/574
-        mock_headers.assert_not_called()
-
-        if audit_logging:
-            mock_logger.info.assert_called_once_with(
-                'Message delivered to Kafka event bus: topic=some_topic, partition=some_partition, '
-                f'offset=12345, message_id={metadata.id}, key=b\'\\x00\\x00\\x00\\x00\\x01\\x0cfoobob\''
-            )
-        else:
-            mock_logger.info.assert_not_called()
-
-    # Mock out the serializers for this one so we don't have to deal
-    # with expected Avro bytes -- and they can't call their schema server.
-    @patch(
-        'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
-        return_value=(
-            lambda _key, _ctx: b'key-bytes-here',
-            lambda _value, _ctx: b'value-bytes-here',
-        )
-    )
-    def test_send_to_event_bus(self, mock_get_serializers):
-        with override_settings(
-                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-                EVENT_BUS_TOPIC_PREFIX='prod',
-                SERVICE_VARIANT='test',
-        ):
-            now = datetime.datetime.now(datetime.timezone.utc)
-            metadata = EventsMetadata(event_type=self.signal.event_type,
-                                      time=now, sourcelib=(1, 2, 3))
-            producer_api = ep.create_producer()
-            with patch.object(producer_api, 'producer', autospec=True) as mock_producer:
-                producer_api.send(
-                    signal=self.signal, topic='user-stuff',
-                    event_key_field='user.id', event_data=self.event_data, event_metadata=metadata
-                )
-
-        mock_get_serializers.assert_called_once_with(self.signal, 'user.id')
-
-        expected_headers = {
-                'ce_type': b'org.openedx.learning.auth.session.login.completed.v1',
-                'ce_id': str(metadata.id).encode("utf8"),
-                'ce_source': b'openedx/test/web',
-                'sourcehost': metadata.sourcehost.encode("utf8"),
-                'ce_specversion': b'1.0',
-                'content-type': b'application/avro',
-                'ce_datacontenttype': b'application/avro',
-                'ce_time': now.isoformat().encode("utf8"),
-                'ce_minorversion': b'0',
-                'sourcelib': b'1.2.3',
-            }
-
-        mock_producer.produce.assert_called_once_with(
-            'prod-user-stuff', key=b'key-bytes-here', value=b'value-bytes-here', on_delivery=ANY,
-            headers=expected_headers,
-        )
-
-    @patch(
-        'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
-        return_value=(
-            lambda _key, _ctx: b'key-bytes-here',
-            lambda _value, _ctx: b'value-bytes-here',
-        )
-    )
-    @patch('edx_event_bus_kafka.internal.producer.logger')
-    def test_full_event_data_present_in_key_extraction_error(self, mock_logger, *args):
-        simple_signal = create_simple_signal({'test_data': SubTestData0})
-        with override_settings(
-                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-                EVENT_BUS_TOPIC_PREFIX='dev',
-                SERVICE_VARIANT='test',
-        ):
-            metadata = EventsMetadata(event_type=simple_signal.event_type, minorversion=0)
-            producer_api = ep.create_producer()
-            # force an exception with a bad event_key_field
-            producer_api.send(signal=simple_signal, topic='topic', event_key_field='bad_field',
-                              event_data={'test_data': SubTestData0(sub_name="name", course_id="id")},
-                              event_metadata=metadata)
-
-        (error_string,) = mock_logger.exception.call_args.args
-        assert "event_data={'test_data': SubTestData0(sub_name='name', course_id='id')}" in error_string
-        assert "signal=<OpenEdxPublicSignal: simple.signal>" in error_string
-        assert "initial_topic='topic'" in error_string
-        assert "full_topic='dev-topic'" in error_string
-        assert "event_key_field='bad_field'" in error_string
-        assert "event_type='simple.signal'" in error_string
-        assert "source='openedx/test/web'" in error_string
-        assert f"id=UUID('{metadata.id}')" in error_string
-        assert f"sourcehost='{metadata.sourcehost}'" in error_string
-
-    @patch(
-        'edx_event_bus_kafka.internal.producer.get_serializers', autospec=True,
-        return_value=(
-            lambda _key, _ctx: b'key-bytes-here',
-            lambda _value, _ctx: b'value-bytes-here',
-        )
-    )
-    @patch('edx_event_bus_kafka.internal.producer.logger')
-    def test_full_event_data_present_in_kafka_error(self, mock_logger, *args):
-        simple_signal = create_simple_signal({'test_data': SubTestData0})
-        with override_settings(
-                EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-                EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-                EVENT_BUS_TOPIC_PREFIX='dev',
-                SERVICE_VARIANT='test',
-        ):
-            producer_api = ep.create_producer()
-            metadata = EventsMetadata(event_type=simple_signal.event_type, minorversion=0)
-            with patch.object(producer_api, 'producer', autospec=True) as mock_producer:
-                # imitate a failed send to Kafka
-                mock_producer.produce = Mock(side_effect=Exception('bad!'))
-                producer_api.send(signal=simple_signal, topic='topic', event_key_field='test_data.course_id',
-                                  event_data={'test_data': SubTestData0(sub_name="name", course_id="ABCx")},
-                                  event_metadata=metadata)
-
-        (error_string,) = mock_logger.exception.call_args.args
-        assert "event_data={'test_data': SubTestData0(sub_name='name', course_id='ABCx')}" in error_string
-        assert "signal=<OpenEdxPublicSignal: simple.signal>" in error_string
-        assert "initial_topic='topic'" in error_string
-        assert "full_topic='dev-topic'" in error_string
-        assert "event_key_field='test_data.course_id'" in error_string
-        assert "source='openedx/test/web'" in error_string
-        assert f"id=UUID('{metadata.id}')" in error_string
-        assert f"sourcehost='{metadata.sourcehost}'" in error_string
-        # since we didn't fail until after key extraction we should have an event_key to report
-        assert "event_key='ABCx'" in error_string
-        assert "error=bad!" in error_string
-
-    @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)
-    def test_polling_loop_terminates(self):
-        """
-        Test that polling loop stops as soon as the producer is garbage-collected.
-        """
-        call_count = 0
-
-        def increment_call_count(*args):
-            nonlocal call_count
-            call_count += 1
-
-        mock_producer = Mock(**{'poll.side_effect': increment_call_count})
-        producer_api = ep.KafkaEventProducer(mock_producer)  # Created, starts polling
-
-        # Allow a little time to pass and check that the mock poll has been called
-        time.sleep(1.0)
-        assert call_count >= 3  # some small value; would actually be about 20
-        print(producer_api)  # Use the value here to ensure it isn't GC'd early
-
-        # Allow garbage collection of these objects, then ask for it to happen.
-        producer_api = None
-        mock_producer = None
-        gc.collect()
-
-        time.sleep(0.2)  # small multiple of loop iteration time
-        count_after_gc = call_count
-
-        # Wait a little longer and confirm that the count is no longer rising
-        time.sleep(1.0)
-        assert call_count == count_after_gc
-
-    @override_settings(EVENT_BUS_KAFKA_POLL_INTERVAL_SEC=0.05)
-    def test_polling_loop_robust(self):
-        """
-        Test that polling loop continues even if one call raises an exception.
-        """
-        call_count = 0
-
-        def increment_call_count(*args):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise Exception("Exercise error handler on first iteration")
-
-        mock_producer = Mock(**{'poll.side_effect': increment_call_count})
-        producer_api = ep.KafkaEventProducer(mock_producer)  # Created, starts polling
-
-        # Allow a little time to pass and check that the mock poll has been called
-        time.sleep(1.0)
-        assert call_count >= 3  # some small value; would actually be about 20
-        print(producer_api)  # Use the value here to ensure it isn't GC'd early
-
-    @override_settings(EVENT_BUS_TOPIC_PREFIX='stage')
-    @override_settings(EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345')
-    @override_settings(EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321')
-    @patch('edx_event_bus_kafka.internal.producer.SerializationContext')
-    def test_serialize_and_produce_to_same_topic(self, mock_context):
-        producer_api = ep.create_producer()
-        with patch('edx_event_bus_kafka.internal.producer.AvroSerializer',
-                   return_value=lambda _x, _y: b'bytes-here'):
-            with patch.object(producer_api, 'producer', autospec=True) as mock_producer:
-                producer_api.send(
-                    signal=self.signal, topic='user-stuff',
-                    event_key_field='user.id', event_data=self.event_data,
-                    event_metadata=EventsMetadata(event_type=self.signal.event_type, minorversion=0)
-                )
-
-        mock_context.assert_has_calls([
-            call('stage-user-stuff', 'key', ANY),
-            call('stage-user-stuff', 'value', ANY),
-        ])
-        assert mock_context.call_count == 2
-        mock_producer.produce.assert_called_once_with(
-            'stage-user-stuff', key=b'bytes-here', value=b'bytes-here',
-            on_delivery=ANY,
-            # headers are tested elsewhere, we just want to verify the topics
-            headers=ANY,
-        )
-
-
-class TestCommand(TestCase):
-    """
-    Test produce_event management command
-    """
-    @override_settings(
-      EVENT_BUS_TOPIC_PREFIX='dev',
-      EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL='http://localhost:12345',
-      EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS='localhost:54321',
-    )
-    @patch('edx_event_bus_kafka.management.commands.produce_event.logger')
-    @patch('edx_event_bus_kafka.internal.producer.SerializationContext')
-    def test_command(self, _, fake_logger):
-        producer_api = ep.create_producer()
-        mocked_producer = Mock(autospec=True)
-        producer_api.producer = mocked_producer
-
-        with patch('edx_event_bus_kafka.management.commands.produce_event.create_producer') as mock_create_producer:
-            with patch('edx_event_bus_kafka.internal.producer.AvroSerializer',
-                       return_value=lambda _x, _y: b'bytes-here'):
-                mock_create_producer.return_value = producer_api
-                call_command(Command(),
-                             topic=['test'],
-                             signal=['openedx_events.learning.signals.SESSION_LOGIN_COMPLETED'],
-                             data=['{"user": {"id": 123, "is_active": true,'
-                                   ' "pii":{"username": "foobob", "email": "bob@foo.example", "name": "Bob Foo"}}}'],
-                             key_field=['user.pii.username'],
-                             )
-        # Actual event producing is tested elsewhere, this is just to make sure the command produces *something*
-        mocked_producer.produce.assert_called_once_with('dev-test', key=b'bytes-here', value=b'bytes-here',
-                                                        on_delivery=ANY, headers=ANY,)
-        fake_logger.exception.assert_not_called()
+            assert isinstance(openedx_events.event_bus.get_producer(), ep.RedisEventProducer)

--- a/edx_event_bus_redis/internal/tests/test_utils.py
+++ b/edx_event_bus_redis/internal/tests/test_utils.py
@@ -1,0 +1,213 @@
+"""
+Test header conversion utils
+"""
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import Mock, patch
+from uuid import uuid1
+
+import attr
+import ddt
+import pytest
+from django.test import TestCase, override_settings
+from openedx_events.data import EventsMetadata
+
+from edx_event_bus_kafka.internal.utils import (
+    HEADER_EVENT_TYPE,
+    HEADER_ID,
+    HEADER_SOURCELIB,
+    HEADER_TIME,
+    _get_headers_from_metadata,
+    _get_metadata_from_headers,
+)
+
+
+def side_effects(functions: list):
+    """
+    Given a list of functions, return a new function that will call each one in turn
+    on successive invocations. (The returned function ignores any arguments it is
+    called with.) Each function's return value will be returned. Behavior is
+    undefined if insufficient functions are supplied.
+    """
+    f_iter = iter(functions)
+
+    def inner(*_args, **_kwargs):
+        nonlocal f_iter
+        return next(f_iter)()
+
+    return inner
+
+
+class TestTestHelpers(TestCase):
+    """Tests for local unit test utilities."""
+
+    def test_side_effects(self):
+        f = side_effects([
+            lambda: 5,
+            lambda: 1/0,
+            lambda: 6,
+        ])
+        assert f() == 5
+        with pytest.raises(ArithmeticError):
+            f()
+        assert f(1, 2, 3, a=4, b=5) == 6
+
+
+class FakeMessage:
+    """
+    A fake confluent_kafka.cimpl.Message that we can actually construct for mocking.
+
+    See https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#message
+    """
+
+    def __init__(
+            self, topic: Optional[str] = None, partition: Optional[int] = None, offset: Optional[int] = None,
+            headers: Optional[list] = None, key: Optional[bytes] = None, value=None,
+            error=None, timestamp=None
+    ):
+        self._topic = topic
+        self._partition = partition
+        self._offset = offset
+        self._headers = headers
+        self._key = key
+        self._value = value
+        self._error = error
+        self._timestamp = timestamp
+
+    def topic(self) -> Optional[str]:
+        return self._topic
+
+    def partition(self) -> Optional[int]:
+        return self._partition
+
+    def offset(self) -> Optional[int]:
+        return self._offset
+
+    def headers(self) -> Optional[list]:
+        """List of str/bytes key/value pairs."""
+        return self._headers
+
+    def key(self) -> Optional[bytes]:
+        """Bytes (Avro)."""
+        return self._key
+
+    def value(self):
+        """Deserialized event value."""
+        return self._value
+
+    def error(self):
+        return self._error
+
+    def timestamp(self):
+        return self._timestamp
+
+
+TEST_UUID = uuid1()
+
+
+@ddt.ddt
+class TestUtils(TestCase):
+    """ Tests for header conversion utils """
+
+    def test_headers_from_event_metadata(self):
+        """
+        Check we can generate message headers from an EventsMetadata object
+        """
+        with override_settings(SERVICE_VARIANT='test'):
+            metadata = EventsMetadata(event_type="org.openedx.learning.auth.session.login.completed.v1",
+                                      id=TEST_UUID,
+                                      sourcelib=(1, 2, 3),
+                                      sourcehost="host",
+                                      minorversion=0,
+                                      time=datetime.fromisoformat("2023-01-01T14:00:00+00:00"))
+            headers = _get_headers_from_metadata(event_metadata=metadata)
+            self.assertDictEqual(headers, {
+                'ce_type': b'org.openedx.learning.auth.session.login.completed.v1',
+                'ce_id': str(TEST_UUID).encode("utf8"),
+                'ce_source': b'openedx/test/web',
+                'ce_specversion': b'1.0',
+                'sourcehost': b'host',
+                'content-type': b'application/avro',
+                'ce_datacontenttype': b'application/avro',
+                'ce_time': b'2023-01-01T14:00:00+00:00',
+                'sourcelib': b'1.2.3',
+                'ce_minorversion': b'0',
+            })
+
+    def test_metadata_from_headers(self):
+        """
+        Check we can generate an EventsMetadata object from valid message headers
+        """
+        uuid = uuid1()
+        headers = [
+            ('ce_type', b'org.openedx.learning.auth.session.login.completed.v1'),
+            ('ce_id', str(uuid).encode("utf8")),
+            ('ce_source', b'openedx/test/web'),
+            ('ce_specversion', b'1.0'),
+            ('sourcehost', b'testsource'),
+            ('content-type', b'application/avro'),
+            ('ce_datacontenttype', b'application/avro'),
+            ('ce_time', b'2023-01-01T14:00:00+00:00'),
+            ('sourcelib', b'1.2.3'),
+            ('minorversion', b'0')
+        ]
+        generated_metadata = _get_metadata_from_headers(headers)
+        expected_metadata = EventsMetadata(
+            event_type="org.openedx.learning.auth.session.login.completed.v1",
+            id=uuid,
+            minorversion=0,
+            source='openedx/test/web',
+            sourcehost='testsource',
+            time=datetime.fromisoformat("2023-01-01T14:00:00+00:00"),
+            sourcelib=(1, 2, 3),
+        )
+        self.assertDictEqual(attr.asdict(generated_metadata), attr.asdict(expected_metadata))
+
+    TEST_UUID_BYTES = str(TEST_UUID).encode("utf8")
+
+    @patch('edx_event_bus_kafka.internal.utils.oed.datetime')
+    @ddt.data(
+        (TEST_UUID_BYTES, None, None, False),  # As long as we have a ce_id header, we can continue
+        (b'bad', None, None, True),  # bad uuid
+        (TEST_UUID_BYTES, b'bad', None, True),  # badly-formatted ce_time
+        (TEST_UUID_BYTES, None, b'bad', True),  # badly-formatted sourcelib
+        (None, None, None, True),
+    )
+    @ddt.unpack
+    def test_generate_metadata_from_missing_or_bad_headers(self, msg_id, msg_time, source_lib, should_raise, mock_dt):
+        """
+        Check that we raise an exception iff there are missing required headers, or some of them are unparseable
+        """
+        now = datetime.now(timezone.utc)
+        mock_dt.now = Mock(return_value=now)
+        headers = filter(lambda x: x[1] is not None, [
+            (HEADER_ID.message_header_key, msg_id),
+            (HEADER_TIME.message_header_key, msg_time),
+            (HEADER_SOURCELIB.message_header_key, source_lib),
+            (HEADER_EVENT_TYPE.message_header_key, b'abc')
+        ])
+        if should_raise:
+            with pytest.raises(Exception):
+                _get_metadata_from_headers(headers)
+        else:
+            # check that we use all the regular EventsMetadata defaults for missing fields by constructing one
+            # and comparing it to the one generated from _get_metadata_from_headers
+            expected_metadata = EventsMetadata(event_type="abc", id=TEST_UUID)
+            generated_metadata = _get_metadata_from_headers(headers)
+            self.assertDictEqual(attr.asdict(generated_metadata), attr.asdict(expected_metadata))
+
+    def test_generate_metadata_fails_with_duplicate_headers(self):
+        """
+        Check that we raise if there are duplicate headers
+        """
+        headers = [
+            (HEADER_ID.message_header_key, str(TEST_UUID).encode("utf-8")),
+            (HEADER_ID.message_header_key, str(uuid1()).encode("utf-8")),
+            (HEADER_EVENT_TYPE.message_header_key, b'abc')
+        ]
+        with pytest.raises(Exception) as exc_info:
+            _get_metadata_from_headers(headers)
+
+        assert exc_info.value.args == (
+            "Multiple \"ce_id\" headers on message. Cannot determine correct metadata.",
+        )

--- a/edx_event_bus_redis/internal/tests/test_utils.py
+++ b/edx_event_bus_redis/internal/tests/test_utils.py
@@ -61,14 +61,14 @@ class FakeMessage:
     """
 
     def __init__(
-            self,
-            topic: Optional[str]=None,
-            headers: Optional[list]=None,
-            key: Optional[bytes]=None,
-            value=None,
-            error=None,
-            timestamp=None
-        ):
+        self,
+        topic: Optional[str] = None,
+        headers: Optional[list] = None,
+        key: Optional[bytes] = None,
+        value=None,
+        error=None,
+        timestamp=None
+    ):
         self._topic = topic
         self._headers = headers
         self._key = key

--- a/edx_event_bus_redis/internal/utils.py
+++ b/edx_event_bus_redis/internal/utils.py
@@ -1,0 +1,171 @@
+"""
+Utilities for converting between message headers and EventsMetadata
+"""
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+import openedx_events.data as oed
+from edx_toggles.toggles import SettingToggle
+
+logger = logging.getLogger(__name__)
+
+# .. toggle_name: EVENT_BUS_KAFKA_AUDIT_LOGGING_ENABLED
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: True
+# .. toggle_description: If True, whenever an event is produced or consumed, log enough
+#   information to uniquely identify it for debugging purposes. This will not include
+#   all the data on the event, but at a minimum will include topic, partition, offset,
+#   message ID, and key. Deployers may wish to disable this if log volume is excessive.
+# .. toggle_use_cases: opt_out
+# .. toggle_creation_date: 2023-02-07
+AUDIT_LOGGING_ENABLED = SettingToggle('EVENT_BUS_KAFKA_AUDIT_LOGGING_ENABLED', default=True)
+
+
+def _sourcelib_tuple_to_str(sourcelib: Tuple):
+    return ".".join(map(str, sourcelib))
+
+
+def _sourcelib_str_to_tuple(sourcelib_as_str: str):
+    return tuple(map(int, sourcelib_as_str.split(".")))
+
+
+class MessageHeader:
+    """
+    Utility class for converting between message headers and EventsMetadata objects
+    """
+    _mapping = {}
+    instances = []
+
+    def __init__(self, message_header_key, event_metadata_field=None, to_metadata=None, from_metadata=None):
+        self.message_header_key = message_header_key
+        self.event_metadata_field = event_metadata_field
+        self.to_metadata = to_metadata or (lambda x: x)
+        self.from_metadata = from_metadata or (lambda x: x)
+        self.__class__.instances.append(self)
+        self.__class__._mapping[self.message_header_key] = self
+
+
+HEADER_EVENT_TYPE = MessageHeader("ce_type", event_metadata_field="event_type")
+HEADER_ID = MessageHeader("ce_id", event_metadata_field="id", from_metadata=str, to_metadata=UUID)
+HEADER_SOURCE = MessageHeader("ce_source", event_metadata_field="source")
+HEADER_SPEC_VERSION = MessageHeader("ce_specversion")
+HEADER_TIME = MessageHeader("ce_time", event_metadata_field="time",
+                            to_metadata=lambda x: datetime.fromisoformat(x),  # pylint: disable=unnecessary-lambda
+                            from_metadata=lambda x: x.isoformat())
+HEADER_MINORVERSION = MessageHeader("ce_minorversion", event_metadata_field="minorversion", to_metadata=int,
+                                    from_metadata=str)
+
+# not CloudEvent headers, so no "ce" prefix
+HEADER_SOURCEHOST = MessageHeader("sourcehost", event_metadata_field="sourcehost")
+HEADER_SOURCELIB = MessageHeader("sourcelib", event_metadata_field="sourcelib",
+                                 to_metadata=_sourcelib_str_to_tuple, from_metadata=_sourcelib_tuple_to_str)
+
+# The documentation is unclear as to which of the following two headers to use for content type, so for now
+# use both
+HEADER_CONTENT_TYPE = MessageHeader("content-type")
+HEADER_DATA_CONTENT_TYPE = MessageHeader("ce_datacontenttype")
+
+
+def get_message_header_values(headers: List, header: MessageHeader) -> List[str]:
+    """
+    Return all values for this header.
+
+    Arguments:
+        headers: List of key/value tuples. Keys are strings, values are bytestrings.
+        header: The MessageHeader to look for.
+
+    Returns:
+        List of zero or more header values decoded as strings.
+    """
+    # CloudEvents specifies using UTF-8 for header values, so let's be explicit.
+    return [value.decode("utf-8") for key, value in headers if key == header.message_header_key]
+
+
+def last_message_header_value(headers: List, header: MessageHeader) -> Optional[str]:
+    """
+    Return the value for the header with the specified key, if there is at least one.
+
+    We should not ordinarily expect there to be more than one instance of a header.
+    However, if there is one, this function will return the last value of it. (The
+    latest value may have been intended to override an earlier value.)
+
+    Arguments:
+        headers: List of key/value tuples. Keys are strings, values are bytestrings.
+        header: The MessageHeader to look for.
+
+    Returns:
+        Decoded value of the last header with this key, or None if there are none.
+    """
+    return next(reversed(get_message_header_values(headers, header)), None)
+
+
+def _get_metadata_from_headers(headers: List[Tuple]):
+    """
+    Create an EventsMetadata object from the headers of a Kafka message
+
+    Arguments
+        headers: The list of headers returned from calling message.headers() on a consumed message
+
+    Returns
+        An instance of EventsMetadata with the parameters from the headers. Any fields missing from the headers
+         are set to the defaults of the EventsMetadata class
+    """
+    # Transform list of (header, value) tuples to a {header: [list of values]} dict. Necessary as an intermediate
+    # step because there is no guarantee of unique headers in the list of tuples
+    headers_as_dict = defaultdict(list)
+    metadata_kwargs = {}
+    for key, value in headers:
+        headers_as_dict[key].append(value)
+
+    # go through all the headers we care about and set the appropriate field
+    for header in MessageHeader.instances:
+        metadata_field = header.event_metadata_field
+        if not metadata_field:
+            continue
+        header_key = header.message_header_key
+        header_values = headers_as_dict[header_key]
+        if len(header_values) == 0:
+            # the id is required, everything else we make optional for now
+            if header_key == HEADER_ID.message_header_key:
+                raise Exception(f"Missing \"{header_key}\" header on message, cannot continue")
+            logger.warning(f"Missing \"{header_key}\" header on message, will use EventsMetadata default")
+            continue
+        if len(header_values) > 1:
+            raise Exception(
+                f"Multiple \"{header_key}\" headers on message. Cannot determine correct metadata."
+            )
+        header_value = header_values[0].decode("utf-8")
+        metadata_kwargs[header.event_metadata_field] = header.to_metadata(header_value)
+    return oed.EventsMetadata(**metadata_kwargs)
+
+
+def _get_headers_from_metadata(event_metadata: oed.EventsMetadata):
+    """
+    Create a dictionary of CloudEvent-compliant Kafka headers from an EventsMetadata object.
+
+    This method assumes the EventsMetadata object was the one sent with the event data to the original signal handler.
+
+    Arguments:
+        event_metadata: An EventsMetadata object sent by an OpenEdxPublicSignal
+
+    Returns:
+        A dictionary of headers where the keys are strings and values are binary
+    """
+    values = {
+        # Always 1.0. See "Fields" in OEP-41
+        HEADER_SPEC_VERSION.message_header_key: b'1.0',
+        HEADER_CONTENT_TYPE.message_header_key: b'application/avro',
+        HEADER_DATA_CONTENT_TYPE.message_header_key: b'application/avro',
+    }
+    for header in MessageHeader.instances:
+        if not header.event_metadata_field:
+            continue
+        event_metadata_value = getattr(event_metadata, header.event_metadata_field)
+        # CloudEvents specifies using UTF-8; that should be the default, but let's make it explicit.
+        values[header.message_header_key] = header.from_metadata(event_metadata_value).encode("utf8")
+
+    return values

--- a/edx_event_bus_redis/internal/utils.py
+++ b/edx_event_bus_redis/internal/utils.py
@@ -99,7 +99,7 @@ def last_message_header_value(headers: List, header: MessageHeader) -> Optional[
 
 def get_metadata_from_headers(headers: List[Tuple]):
     """
-    Create an EventsMetadata object from the headers of a Kafka message
+    Create an EventsMetadata object from the headers of a Redis message
 
     Arguments
         headers: The list of headers returned from calling message.headers() on a consumed message

--- a/edx_event_bus_redis/internal/utils.py
+++ b/edx_event_bus_redis/internal/utils.py
@@ -63,6 +63,7 @@ HEADER_SOURCEHOST = MessageHeader("sourcehost", event_metadata_field="sourcehost
 HEADER_SOURCELIB = MessageHeader("sourcelib", event_metadata_field="sourcelib",
                                  to_metadata=_sourcelib_str_to_tuple, from_metadata=_sourcelib_tuple_to_str)
 
+
 def get_message_header_values(headers: List, header: MessageHeader) -> List[str]:
     """
     Return all values for this header.
@@ -124,11 +125,13 @@ def get_metadata_from_headers(headers: List[Tuple]):
         if len(header_values) == 0:
             # the id is required, everything else we make optional for now
             if header_key == HEADER_ID.message_header_key:
-                raise Exception(f"Missing \"{header_key}\" header on message, cannot continue")
+                raise Exception(  # pylint: disable=broad-exception-raised
+                    f"Missing \"{header_key}\" header on message, cannot continue"
+                )
             logger.warning(f"Missing \"{header_key}\" header on message, will use EventsMetadata default")
             continue
         if len(header_values) > 1:
-            raise Exception(
+            raise Exception(  # pylint: disable=broad-exception-raised
                 f"Multiple \"{header_key}\" headers on message. Cannot determine correct metadata."
             )
         header_value = header_values[0].decode("utf-8")

--- a/edx_event_bus_redis/management/commands/__init__.py
+++ b/edx_event_bus_redis/management/commands/__init__.py
@@ -1,0 +1,5 @@
+"""
+Management commands for the Kafka implementation.
+
+(Django requires this package structure.)
+"""

--- a/edx_event_bus_redis/management/commands/__init__.py
+++ b/edx_event_bus_redis/management/commands/__init__.py
@@ -1,5 +1,5 @@
 """
-Management commands for the Kafka implementation.
+Management commands for the Redis implementation.
 
 (Django requires this package structure.)
 """

--- a/edx_event_bus_redis/management/commands/consume_events.py
+++ b/edx_event_bus_redis/management/commands/consume_events.py
@@ -1,0 +1,5 @@
+"""
+Makes ``consume_events`` management command available.
+"""
+
+from edx_event_bus_kafka.internal.consumer import ConsumeEventsCommand as Command  # pylint: disable=unused-import

--- a/edx_event_bus_redis/management/commands/consume_events.py
+++ b/edx_event_bus_redis/management/commands/consume_events.py
@@ -2,4 +2,4 @@
 Makes ``consume_events`` management command available.
 """
 
-from edx_event_bus_kafka.internal.consumer import ConsumeEventsCommand as Command  # pylint: disable=unused-import
+from edx_event_bus_redis.internal.consumer import ConsumeEventsCommand as Command  # pylint: disable=unused-import

--- a/edx_event_bus_redis/management/commands/produce_event.py
+++ b/edx_event_bus_redis/management/commands/produce_event.py
@@ -1,0 +1,68 @@
+"""
+Produce a single event. Intended for testing.
+
+Implements required ``APP.management.commands.*.Command`` structure.
+"""
+
+import json
+import logging
+
+from django.core.management.base import BaseCommand
+from django.utils.module_loading import import_string
+from openedx_events.data import EventsMetadata
+
+from edx_event_bus_kafka.internal.producer import create_producer
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command to produce a test event to the event bus.
+    """
+    help = """
+    Produce a single test event with the given data to the specified Kafka topic.
+
+    example:
+        python3 manage.py cms produce_event --signal openedx_events.learning.signals.SESSION_LOGIN_COMPLETED \
+          --topic user-login --key-field user.pii.username \
+          --data '{"user": {
+                    "id": 123,
+                    "is_active": true,
+                    "pii": {"username": "foobob", "email": "bob@foo.example", "name": "Bob Foo"}}}'
+    """
+
+    def add_arguments(self, parser):
+
+        parser.add_argument(
+            '--signal', nargs=1, required=True,
+            help="Module:variable path to an OpenEdxPublicSignal instance",
+        )
+        parser.add_argument(
+            '--topic', nargs=1, required=True,
+            help="Topic to produce to (without environment prefix)",
+        )
+        parser.add_argument(
+            '--key-field', nargs=1, required=True,
+            help="Dotted string representing path to event key in event data dictionary",
+        )
+        parser.add_argument(
+            '--data', nargs=1, required=True,
+            help="JSON representation of kwargs dict appropriate for the signal",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            signal = import_string(options['signal'][0])
+            event_type = signal.event_type
+            producer = create_producer()
+            producer.send(
+                signal=signal,
+                topic=options['topic'][0],
+                event_key_field=options['key_field'][0],
+                event_data=json.loads(options['data'][0]),
+                event_metadata=EventsMetadata(event_type=event_type),
+            )
+            producer.prepare_for_shutdown()  # otherwise command may exit before delivery is complete
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Error producing Kafka event")

--- a/edx_event_bus_redis/management/commands/produce_event.py
+++ b/edx_event_bus_redis/management/commands/produce_event.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand
 from django.utils.module_loading import import_string
 from openedx_events.data import EventsMetadata
 
-from edx_event_bus_kafka.internal.producer import create_producer
+from edx_event_bus_redis.internal.producer import create_producer
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,5 @@ class Command(BaseCommand):
                 event_data=json.loads(options['data'][0]),
                 event_metadata=EventsMetadata(event_type=event_type),
             )
-            producer.prepare_for_shutdown()  # otherwise command may exit before delivery is complete
         except Exception:  # pylint: disable=broad-except
             logger.exception("Error producing Kafka event")

--- a/edx_event_bus_redis/management/commands/produce_event.py
+++ b/edx_event_bus_redis/management/commands/produce_event.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
     Management command to produce a test event to the event bus.
     """
     help = """
-    Produce a single test event with the given data to the specified Kafka topic.
+    Produce a single test event with the given data to the specified Redis topic.
 
     example:
         python3 manage.py cms produce_event --signal openedx_events.learning.signals.SESSION_LOGIN_COMPLETED \
@@ -64,4 +64,4 @@ class Command(BaseCommand):
                 event_metadata=EventsMetadata(event_type=event_type),
             )
         except Exception:  # pylint: disable=broad-except
-            logger.exception("Error producing Kafka event")
+            logger.exception("Error producing Redis event")

--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import, wrong-import-position
+            import django  # pylint: disable=unused-import
         except ImportError as import_error:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,3 +5,5 @@ Django             # Web application framework
 openedx-events>=5.0.0                   # Events API
 edx_django_utils
 edx_toggles
+
+walrus             # redis python client

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,4 +2,6 @@
 -c constraints.txt
 
 Django             # Web application framework
-
+openedx-events>=5.0.0                   # Events API
+edx_django_utils
+edx_toggles

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,8 @@
 #
 asgiref==3.6.0
     # via django
+async-timeout==4.0.2
+    # via redis
 attrs==22.2.0
     # via openedx-events
 cffi==1.15.1
@@ -66,6 +68,8 @@ pytz==2022.7.1
     # via django
 pyyaml==6.0
     # via code-annotations
+redis==4.5.1
+    # via walrus
 sqlparse==0.4.3
     # via django
 stevedore==5.0.0
@@ -75,3 +79,5 @@ stevedore==5.0.0
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
+walrus==0.9.2
+    # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,11 +6,72 @@
 #
 asgiref==3.6.0
     # via django
+attrs==22.2.0
+    # via openedx-events
+cffi==1.15.1
+    # via pynacl
+click==8.1.3
+    # via
+    #   code-annotations
+    #   edx-django-utils
+code-annotations==1.3.0
+    # via edx-toggles
 django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
+    #   django-crum
+    #   edx-django-utils
+    #   edx-toggles
+    #   openedx-events
+django-crum==0.7.9
+    # via
+    #   edx-django-utils
+    #   edx-toggles
+django-waffle==3.0.0
+    # via
+    #   edx-django-utils
+    #   edx-toggles
+edx-django-utils==5.2.0
+    # via
+    #   -r requirements/base.in
+    #   edx-toggles
+edx-opaque-keys[django]==2.3.0
+    # via openedx-events
+edx-toggles==5.0.0
+    # via -r requirements/base.in
+fastavro==1.7.2
+    # via openedx-events
+jinja2==3.1.2
+    # via code-annotations
+markupsafe==2.1.2
+    # via jinja2
+newrelic==8.7.0
+    # via edx-django-utils
+openedx-events==5.1.0
+    # via -r requirements/base.in
+pbr==5.11.1
+    # via stevedore
+psutil==5.9.4
+    # via edx-django-utils
+pycparser==2.21
+    # via cffi
+pymongo==3.13.0
+    # via edx-opaque-keys
+pynacl==1.5.0
+    # via edx-django-utils
+python-slugify==8.0.0
+    # via code-annotations
 pytz==2022.7.1
     # via django
+pyyaml==6.0
+    # via code-annotations
 sqlparse==0.4.3
     # via django
+stevedore==5.0.0
+    # via
+    #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
+text-unidecode==1.3
+    # via python-slugify

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,7 +10,7 @@ charset-normalizer==3.0.1
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==7.1.0
+coverage==7.2.0
     # via codecov
 distlib==0.3.6
     # via virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,6 +13,10 @@ astroid==2.14.2
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
+async-timeout==4.0.2
+    # via
+    #   -r requirements/quality.txt
+    #   redis
 attrs==22.2.0
     # via
     #   -r requirements/quality.txt
@@ -258,6 +262,10 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
+redis==4.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   walrus
 requests==2.28.2
     # via
     #   -r requirements/ci.txt
@@ -321,6 +329,8 @@ virtualenv==20.19.0
     # via
     #   -r requirements/ci.txt
     #   tox
+walrus==0.9.2
+    # via -r requirements/quality.txt
 wheel==0.38.4
     # via
     #   -r requirements/pip-tools.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,6 +16,7 @@ astroid==2.14.2
 attrs==22.2.0
     # via
     #   -r requirements/quality.txt
+    #   openedx-events
     #   pytest
 build==0.10.0
     # via
@@ -25,6 +26,10 @@ certifi==2022.12.7
     # via
     #   -r requirements/ci.txt
     #   requests
+cffi==1.15.1
+    # via
+    #   -r requirements/quality.txt
+    #   pynacl
 chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.0.1
@@ -37,6 +42,7 @@ click==8.1.3
     #   -r requirements/quality.txt
     #   click-log
     #   code-annotations
+    #   edx-django-utils
     #   edx-lint
     #   pip-tools
 click-log==0.4.0
@@ -47,14 +53,17 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+    #   edx-toggles
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==7.1.0
+coverage[toml]==7.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
+ddt==1.6.0
+    # via -r requirements/quality.txt
 diff-cover==7.5.0
     # via -r requirements/dev.in
 dill==0.3.6
@@ -69,15 +78,43 @@ django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
+    #   django-crum
+    #   edx-django-utils
     #   edx-i18n-tools
+    #   edx-toggles
+    #   openedx-events
+django-crum==0.7.9
+    # via
+    #   -r requirements/quality.txt
+    #   edx-django-utils
+    #   edx-toggles
+django-waffle==3.0.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-django-utils
+    #   edx-toggles
+edx-django-utils==5.2.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-toggles
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
 edx-lint==5.3.2
+    # via -r requirements/quality.txt
+edx-opaque-keys[django]==2.3.0
+    # via
+    #   -r requirements/quality.txt
+    #   openedx-events
+edx-toggles==5.0.0
     # via -r requirements/quality.txt
 exceptiongroup==1.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
+fastavro==1.7.2
+    # via
+    #   -r requirements/quality.txt
+    #   openedx-events
 filelock==3.9.0
     # via
     #   -r requirements/ci.txt
@@ -112,6 +149,12 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
+newrelic==8.7.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-django-utils
+openedx-events==5.1.0
+    # via -r requirements/quality.txt
 packaging==23.0
     # via
     #   -r requirements/ci.txt
@@ -141,14 +184,22 @@ pluggy==1.0.0
     #   diff-cover
     #   pytest
     #   tox
-polib==1.1.1
+polib==1.2.0
     # via edx-i18n-tools
+psutil==5.9.4
+    # via
+    #   -r requirements/quality.txt
+    #   edx-django-utils
 py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
 pycodestyle==2.10.0
     # via -r requirements/quality.txt
+pycparser==2.21
+    # via
+    #   -r requirements/quality.txt
+    #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.14.0
@@ -173,6 +224,14 @@ pylint-plugin-utils==0.7
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
+pymongo==3.13.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -r requirements/quality.txt
+    #   edx-django-utils
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
@@ -221,6 +280,8 @@ stevedore==5.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,6 +10,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
+async-timeout==4.0.2
+    # via
+    #   -r requirements/test.txt
+    #   redis
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
@@ -201,6 +205,10 @@ pyyaml==6.0
     #   sphinx-book-theme
 readme-renderer==37.3
     # via twine
+redis==4.5.1
+    # via
+    #   -r requirements/test.txt
+    #   walrus
 requests==2.28.2
     # via
     #   requests-toolbelt
@@ -269,6 +277,8 @@ urllib3==1.26.14
     # via
     #   requests
     #   twine
+walrus==0.9.2
+    # via -r requirements/test.txt
 webencodings==0.5.1
     # via bleach
 zipp==3.14.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,6 +13,7 @@ asgiref==3.6.0
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
+    #   openedx-events
     #   pytest
 babel==2.11.0
     # via sphinx
@@ -24,31 +25,71 @@ build==0.10.0
     # via -r requirements/doc.in
 certifi==2022.12.7
     # via requests
+cffi==1.15.1
+    # via
+    #   -r requirements/test.txt
+    #   cryptography
+    #   pynacl
 charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   edx-django-utils
 code-annotations==1.3.0
-    # via -r requirements/test.txt
-coverage[toml]==7.1.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-toggles
+coverage[toml]==7.2.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
+cryptography==39.0.1
+    # via secretstorage
+ddt==1.6.0
+    # via -r requirements/test.txt
 django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
+    #   django-crum
+    #   edx-django-utils
+    #   edx-toggles
+    #   openedx-events
+django-crum==0.7.9
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-toggles
+django-waffle==3.0.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-toggles
 docutils==0.17.1
     # via
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
+edx-django-utils==5.2.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-toggles
+edx-opaque-keys[django]==2.3.0
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
+edx-toggles==5.0.0
+    # via -r requirements/test.txt
 exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
+fastavro==1.7.2
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 idna==3.4
     # via requests
 imagesize==1.4.1
@@ -66,6 +107,10 @@ iniconfig==2.0.0
     #   pytest
 jaraco-classes==3.2.3
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -83,6 +128,12 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.0.0
     # via jaraco-classes
+newrelic==8.7.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+openedx-events==5.1.0
+    # via -r requirements/test.txt
 packaging==23.0
     # via
     #   -r requirements/test.txt
@@ -100,6 +151,14 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
+psutil==5.9.4
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+pycparser==2.21
+    # via
+    #   -r requirements/test.txt
+    #   cffi
 pydata-sphinx-theme==0.8.1
     # via sphinx-book-theme
 pygments==2.14.0
@@ -107,6 +166,14 @@ pygments==2.14.0
     #   readme-renderer
     #   rich
     #   sphinx
+pymongo==3.13.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
 pytest==7.2.1
@@ -145,6 +212,8 @@ rfc3986==2.0.0
     # via twine
 rich==13.3.1
     # via twine
+secretstorage==3.3.3
+    # via keyring
 six==1.16.0
     # via bleach
 snowballstemmer==2.2.0
@@ -179,6 +248,8 @@ stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,12 +15,18 @@ astroid==2.14.2
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
+    #   openedx-events
     #   pytest
+cffi==1.15.1
+    # via
+    #   -r requirements/test.txt
+    #   pynacl
 click==8.1.3
     # via
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
+    #   edx-django-utils
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
@@ -28,22 +34,53 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.1.0
+    #   edx-toggles
+coverage[toml]==7.2.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
+ddt==1.6.0
+    # via -r requirements/test.txt
 dill==0.3.6
     # via pylint
 django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
+    #   django-crum
+    #   edx-django-utils
+    #   edx-toggles
+    #   openedx-events
+django-crum==0.7.9
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-toggles
+django-waffle==3.0.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+    #   edx-toggles
+edx-django-utils==5.2.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-toggles
 edx-lint==5.3.2
     # via -r requirements/quality.in
+edx-opaque-keys[django]==2.3.0
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
+edx-toggles==5.0.0
+    # via -r requirements/test.txt
 exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
+fastavro==1.7.2
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
@@ -64,6 +101,12 @@ markupsafe==2.1.2
     #   jinja2
 mccabe==0.7.0
     # via pylint
+newrelic==8.7.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
+openedx-events==5.1.0
+    # via -r requirements/test.txt
 packaging==23.0
     # via
     #   -r requirements/test.txt
@@ -78,8 +121,16 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
+psutil==5.9.4
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
 pycodestyle==2.10.0
     # via -r requirements/quality.in
+pycparser==2.21
+    # via
+    #   -r requirements/test.txt
+    #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pylint==2.16.2
@@ -96,6 +147,14 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
+pymongo==3.13.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-django-utils
 pytest==7.2.1
     # via
     #   -r requirements/test.txt
@@ -129,6 +188,8 @@ stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
 text-unidecode==1.3
     # via
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,6 +12,10 @@ astroid==2.14.2
     # via
     #   pylint
     #   pylint-celery
+async-timeout==4.0.2
+    # via
+    #   -r requirements/test.txt
+    #   redis
 attrs==22.2.0
     # via
     #   -r requirements/test.txt
@@ -176,6 +180,10 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+redis==4.5.1
+    # via
+    #   -r requirements/test.txt
+    #   walrus
 six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
@@ -206,5 +214,7 @@ typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
+walrus==0.9.2
+    # via -r requirements/test.txt
 wrapt==1.14.1
     # via astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,3 +6,4 @@
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.
+ddt                       # Run a test case multiple times with different input

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,30 +9,101 @@ asgiref==3.6.0
     #   -r requirements/base.txt
     #   django
 attrs==22.2.0
-    # via pytest
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
+    #   pytest
+cffi==1.15.1
+    # via
+    #   -r requirements/base.txt
+    #   pynacl
 click==8.1.3
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-utils
 code-annotations==1.3.0
-    # via -r requirements/test.in
-coverage[toml]==7.1.0
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.in
+    #   edx-toggles
+coverage[toml]==7.2.0
     # via pytest-cov
+ddt==1.6.0
+    # via -r requirements/test.in
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+    #   django-crum
+    #   edx-django-utils
+    #   edx-toggles
+    #   openedx-events
+django-crum==0.7.9
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-toggles
+django-waffle==3.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+    #   edx-toggles
+edx-django-utils==5.2.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-toggles
+edx-opaque-keys[django]==2.3.0
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
+edx-toggles==5.0.0
+    # via -r requirements/base.txt
 exceptiongroup==1.1.0
     # via pytest
+fastavro==1.7.2
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 markupsafe==2.1.2
-    # via jinja2
+    # via
+    #   -r requirements/base.txt
+    #   jinja2
+newrelic==8.7.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+openedx-events==5.1.0
+    # via -r requirements/base.txt
 packaging==23.0
     # via pytest
 pbr==5.11.1
-    # via stevedore
+    # via
+    #   -r requirements/base.txt
+    #   stevedore
 pluggy==1.0.0
     # via pytest
+psutil==5.9.4
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
+pycparser==2.21
+    # via
+    #   -r requirements/base.txt
+    #   cffi
+pymongo==3.13.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-opaque-keys
+pynacl==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-django-utils
 pytest==7.2.1
     # via
     #   pytest-cov
@@ -42,21 +113,31 @@ pytest-cov==4.0.0
 pytest-django==4.5.2
     # via -r requirements/test.in
 python-slugify==8.0.0
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 pytz==2022.7.1
     # via
     #   -r requirements/base.txt
     #   django
 pyyaml==6.0
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
 sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
     #   django
 stevedore==5.0.0
-    # via code-annotations
+    # via
+    #   -r requirements/base.txt
+    #   code-annotations
+    #   edx-django-utils
+    #   edx-opaque-keys
 text-unidecode==1.3
-    # via python-slugify
+    # via
+    #   -r requirements/base.txt
+    #   python-slugify
 tomli==2.0.1
     # via
     #   coverage

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,6 +8,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
+async-timeout==4.0.2
+    # via
+    #   -r requirements/base.txt
+    #   redis
 attrs==22.2.0
     # via
     #   -r requirements/base.txt
@@ -124,6 +128,10 @@ pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
+redis==4.5.1
+    # via
+    #   -r requirements/base.txt
+    #   walrus
 sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
@@ -142,3 +150,5 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
+walrus==0.9.2
+    # via -r requirements/base.txt


### PR DESCRIPTION
**Description:** Replicates [event_bus_kafka](https://github.com/openedx/event-bus-kafka) and removes kafka specific code. Cleans up producer and consumer to make it easier to add redis streams implementation.

_Since there are a lot of files added, it would be easier to review commit by commit._

**Tickets:** 
* `Private-ref`: [BB-7169](https://tasks.opencraft.com/browse/BB-7169)
* #1 


**Merge deadline:** List merge deadline (if any)

**Testing instructions:**

1. Make sure tests are passing.
2. Make sure kafka specific code is removed.

**Reviewers:**
- [ ] @keithgg
- [ ] @bmtcril 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

