### PR TITLE
feat: redis producer

### DIFF
--- a/edx_event_bus_redis/internal/producer.py
+++ b/edx_event_bus_redis/internal/producer.py
@@ -71,7 +71,7 @@ class ProducingContext:
         message_id = self.event_metadata.id
         # See ADR for details on why certain fields were included or omitted.
         logger.info(
-            f"Message delivered to Redis event bus: topic={self.full_topic} "
+            f"Message delivered to Redis event bus: topic={self.full_topic}, "
             f"message_id={message_id}, signal={self.signal}, redis_msg_id={redis_msg_id}"
         )
 

--- a/edx_event_bus_redis/internal/producer.py
+++ b/edx_event_bus_redis/internal/producer.py
@@ -11,7 +11,7 @@ import attr
 from edx_django_utils.monitoring import record_exception
 from openedx_events.data import EventsMetadata
 from openedx_events.event_bus import EventBusProducer
-from openedx_events.event_bus.avro.tests.test_utilities import serialize_event_data_to_bytes
+from openedx_events.event_bus.avro.serializer import serialize_event_data_to_bytes
 from openedx_events.tooling import OpenEdxPublicSignal
 from walrus import Database
 

--- a/edx_event_bus_redis/internal/producer.py
+++ b/edx_event_bus_redis/internal/producer.py
@@ -11,10 +11,12 @@ import attr
 from edx_django_utils.monitoring import record_exception
 from openedx_events.data import EventsMetadata
 from openedx_events.event_bus import EventBusProducer
+from openedx_events.event_bus.avro.tests.test_utilities import serialize_event_data_to_bytes
 from openedx_events.tooling import OpenEdxPublicSignal
+from walrus import Database
 
 from .config import get_full_topic, load_common_settings
-from .utils import AUDIT_LOGGING_ENABLED
+from .utils import AUDIT_LOGGING_ENABLED, get_headers_from_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -53,32 +55,25 @@ class ProducingContext:
         """Create a logging-friendly string"""
         return " ".join([f"{key}={value!r}" for key, value in attr.asdict(self, recurse=False).items()])
 
-    def on_event_deliver(self, err, evt):
+    def on_event_deliver(self, redis_msg_id):
         """
-        Simple callback method for debugging event production
-
-        If there is any error, log all the known information about the calling context so the event can be recreated
-        and/or resent later. This log will not contain the exact headers but will contain the EventsMetadata object
-        that can be used to recreate them.
+        Simple method for debugging event production
 
         Arguments:
-            err: Error if event production failed
-            evt: Event that was delivered (or failed to be delivered)
+            msg_id: Stream event msg_id.
         """
-        if err is not None:
-            record_producing_error(err, self)
-        else:
-            # Audit logging on success. See ADR: docs/decisions/0010_audit_logging.rst
-            if not AUDIT_LOGGING_ENABLED.is_enabled():
-                return
+        # TODO: see if below ADR can be moved to openedx_events.
+        # Audit logging on success.
+        # See ADR: https://github.com/openedx/event-bus-kafka/blob/main/docs/decisions/0010_audit_logging.rst
+        if not AUDIT_LOGGING_ENABLED.is_enabled():
+            return
 
-            # `evt.headers()` is None in this callback, so we need to use the bound data.
-            message_id = self.event_metadata.id
-            # See ADR for details on why certain fields were included or omitted.
-            logger.info(
-                f"Message delivered to Redis event bus: topic={evt.topic()} "
-                f"message_id={message_id}, key={evt.key()}"
-            )
+        message_id = self.event_metadata.id
+        # See ADR for details on why certain fields were included or omitted.
+        logger.info(
+            f"Message delivered to Redis event bus: topic={self.full_topic} "
+            f"message_id={message_id}, signal={self.signal}, redis_msg_id={redis_msg_id}"
+        )
 
 
 class RedisEventProducer(EventBusProducer):
@@ -103,22 +98,30 @@ class RedisEventProducer(EventBusProducer):
             signal: The original OpenEdxPublicSignal the event was sent to
             topic: The base (un-prefixed) event bus topic for the event
             event_key_field: Path to the event data field to use as the event key (period-delimited
-              string naming the dictionary keys to descend)
+              string naming the dictionary keys to descend). Not used in redis event bus.
             event_data: The event data (kwargs) sent to the signal
             event_metadata: An EventsMetadata object with all the metadata necessary for the CloudEvent spec
         """
 
         # keep track of the initial arguments for recreating the event in the logs if necessary later
-        context = ProducingContext(signal=signal, initial_topic=topic, event_key_field=event_key_field,
-                                   event_data=event_data, event_metadata=event_metadata)
+        context = ProducingContext(
+            signal=signal,
+            initial_topic=topic,
+            event_key_field=event_key_field,
+            event_data=event_data,
+            event_metadata=event_metadata
+        )
         try:
             full_topic = get_full_topic(topic)
             context.full_topic = full_topic
+            headers = get_headers_from_metadata(event_metadata)
+            serialized_event_data = serialize_event_data_to_bytes(event_data, signal)
+            stream_data = {'event_data': serialized_event_data, **headers}
 
-            # TODO: add event to redis stream
+            stream = self.client.Stream(full_topic)
+            msg_id = stream.add(stream_data)
+            context.on_event_deliver(msg_id)
         except Exception as e:  # pylint: disable=broad-except
-            # Errors caused by the produce call should be handled by the on_delivery callback.
-            # Here we might expect serialization errors, or any errors from preparing to produce.
             record_producing_error(e, context)
 
 
@@ -127,9 +130,8 @@ def create_producer() -> Optional[RedisEventProducer]:
     Create a Producer API instance. Caller should cache the returned object.
     """
     producer_settings = load_common_settings()
-    if producer_settings is None:
+    if producer_settings is None or "url" not in producer_settings:
         return None
 
-    # TODO create redis client
-    client = None
+    client = Database.from_url(producer_settings['url'])
     return RedisEventProducer(client)

--- a/edx_event_bus_redis/internal/tests/test_producer.py
+++ b/edx_event_bus_redis/internal/tests/test_producer.py
@@ -152,7 +152,7 @@ class TestEventProducer(TestCase):
             metadata = EventsMetadata(event_type=simple_signal.event_type, minorversion=0)
             producer_api = ep.create_producer()
             with patch.object(producer_api, 'client', autospec=True) as mock_client:
-                # imitate a failed send to Kafka
+                # imitate a failed send to Redis
                 mock_client.Stream = Mock(side_effect=Exception('bad!'))
                 producer_api.send(
                     signal=simple_signal,

--- a/edx_event_bus_redis/internal/tests/test_producer.py
+++ b/edx_event_bus_redis/internal/tests/test_producer.py
@@ -3,15 +3,21 @@ Test the event producer code.
 """
 
 import warnings
+from datetime import datetime, timezone
 from unittest import TestCase
+from unittest.mock import Mock, patch
 
 import ddt
 import openedx_events.event_bus
 import openedx_events.learning.signals
+from django.core.management import call_command
 from django.test import override_settings
+from openedx_events.data import EventsMetadata
+from openedx_events.event_bus.avro.tests.test_utilities import SubTestData0, create_simple_signal
 from openedx_events.learning.data import UserData, UserPersonalData
 
 import edx_event_bus_redis.internal.producer as ep
+from edx_event_bus_redis.management.commands.produce_event import Command
 
 
 @ddt.ddt
@@ -48,7 +54,158 @@ class TestEventProducer(TestCase):
         Also tests basic compliance with the implementation-loader API in openedx-events.
         """
         with override_settings(
-                EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer',
-                EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@locahost:6379/0'
+            EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer',
+            EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@locahost:6379/0'
         ):
             assert isinstance(openedx_events.event_bus.get_producer(), ep.RedisEventProducer)
+
+    @patch('edx_event_bus_redis.internal.producer.logger')
+    @ddt.data(True, False)
+    def test_on_event_deliver(self, audit_logging, mock_logger):
+        metadata = EventsMetadata(
+            event_type=self.signal.event_type,
+            time=datetime.now(timezone.utc),
+            sourcelib=(1, 2, 3),
+        )
+
+        context = ep.ProducingContext(
+            full_topic='some_topic',
+            event_key='foobob',
+            signal=self.signal,
+            initial_topic='bare_topic',
+            event_key_field='a.key.field',
+            event_data=self.event_data,
+            event_metadata=metadata,
+        )
+
+        # ensure on_event_deliver reports the entire calling context if there was an error
+        ep.record_producing_error(Exception("problem!"), context)
+
+        # extract the error message that was produced and check it has all relevant information (order isn't guaranteed
+        # and doesn't actually matter, nor do we want to worry if other information is added later)
+        (error_string,) = mock_logger.exception.call_args.args
+        assert "full_topic='some_topic'" in error_string
+        assert "error=problem!" in error_string
+
+        with override_settings(EVENT_BUS_REDIS_AUDIT_LOGGING_ENABLED=audit_logging):
+            context.on_event_deliver(b'random-msg-id')
+
+        if audit_logging:
+            mock_logger.info.assert_called_once_with(
+                "Message delivered to Redis event bus: topic=some_topic, "
+                f"message_id={metadata.id}, signal={self.signal}, redis_msg_id=b'random-msg-id'"
+            )
+        else:
+            mock_logger.info.assert_not_called()
+
+    # Mock out the serializers for this one so we don't have to deal with expected Avro bytes
+    @patch(
+        'edx_event_bus_redis.internal.producer.serialize_event_data_to_bytes', autospec=True,
+        return_value=b'value-bytes-here',
+    )
+    def test_send_to_event_bus(self, mock_serializer):
+        with override_settings(
+            EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer',
+            EVENT_BUS_REDIS_CONNECTION_URL='redis://locahost:6379/0',
+            EVENT_BUS_TOPIC_PREFIX='prod',
+            SERVICE_VARIANT='test',
+        ):
+            now = datetime.now(timezone.utc)
+            metadata = EventsMetadata(event_type=self.signal.event_type,
+                                      time=now, sourcelib=(1, 2, 3))
+            producer_api = ep.create_producer()
+            with patch.object(producer_api, 'client', autospec=True) as mock_client:
+                stream_mock = Mock()
+                mock_client.Stream.return_value = stream_mock
+                producer_api.send(
+                    signal=self.signal, topic='user-stuff',
+                    event_key_field='user.id', event_data=self.event_data, event_metadata=metadata
+                )
+
+        mock_serializer.assert_called_once_with(self.event_data, self.signal)
+        mock_client.Stream.assert_called_once_with('prod-user-stuff')
+        expected_headers = {
+            'type': b'org.openedx.learning.auth.session.login.completed.v1',
+            'id': str(metadata.id).encode("utf8"),
+            'source': b'openedx/test/web',
+            'sourcehost': metadata.sourcehost.encode("utf8"),
+            'time': now.isoformat().encode("utf8"),
+            'minorversion': b'0',
+            'sourcelib': b'1.2.3',
+        }
+
+        stream_mock.add.assert_called_once_with({'event_data': b'value-bytes-here', **expected_headers})
+
+    @patch(
+        'edx_event_bus_redis.internal.producer.serialize_event_data_to_bytes', autospec=True,
+        return_value=b'value-bytes-here',
+    )
+    @patch('edx_event_bus_redis.internal.producer.logger')
+    def test_full_event_data_present_in_redis_error(self, mock_logger, *args):
+        simple_signal = create_simple_signal({'test_data': SubTestData0})
+        with override_settings(
+            EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer',
+            EVENT_BUS_REDIS_CONNECTION_URL='redis://locahost:6379/0',
+            EVENT_BUS_TOPIC_PREFIX='dev',
+            SERVICE_VARIANT='test',
+        ):
+            metadata = EventsMetadata(event_type=simple_signal.event_type, minorversion=0)
+            producer_api = ep.create_producer()
+            with patch.object(producer_api, 'client', autospec=True) as mock_client:
+                # imitate a failed send to Kafka
+                mock_client.Stream = Mock(side_effect=Exception('bad!'))
+                producer_api.send(
+                    signal=simple_signal,
+                    topic='topic',
+                    event_key_field='bad_field',
+                    event_data={'test_data': SubTestData0(sub_name="name", course_id="id")},
+                    event_metadata=metadata
+                )
+
+        (error_string,) = mock_logger.exception.call_args.args
+        assert "event_data={'test_data': SubTestData0(sub_name='name', course_id='id')}" in error_string
+        assert "signal=<OpenEdxPublicSignal: simple.signal>" in error_string
+        assert "initial_topic='topic'" in error_string
+        assert "full_topic='dev-topic'" in error_string
+        assert "event_key_field='bad_field'" in error_string
+        assert "event_type='simple.signal'" in error_string
+        assert "source='openedx/test/web'" in error_string
+        assert f"id=UUID('{metadata.id}')" in error_string
+        assert f"sourcehost='{metadata.sourcehost}'" in error_string
+
+
+class TestCommand(TestCase):
+    """
+    Test produce_event management command
+    """
+    @override_settings(
+        EVENT_BUS_REDIS_CONNECTION_URL='redis://locahost:6379/0',
+        EVENT_BUS_TOPIC_PREFIX='dev',
+        SERVICE_VARIANT='test',
+    )
+    @patch(
+        'edx_event_bus_redis.internal.producer.serialize_event_data_to_bytes', autospec=True,
+        return_value=b'value-bytes-here',
+    )
+    @patch('edx_event_bus_redis.management.commands.produce_event.logger')
+    def test_command(self, fake_logger, _):
+        producer_api = ep.create_producer()
+        mocked_client = Mock(autospec=True)
+        producer_api.client = mocked_client
+        stream_mock = Mock()
+        mocked_client.Stream.return_value = stream_mock
+
+        with patch('edx_event_bus_redis.management.commands.produce_event.create_producer') as mock_create_producer:
+            mock_create_producer.return_value = producer_api
+            call_command(Command(),
+                         topic=['test'],
+                         signal=['openedx_events.learning.signals.SESSION_LOGIN_COMPLETED'],
+                         data=['{"user": {"id": 123, "is_active": true,'
+                               ' "pii":{"username": "foobob", "email": "bob@foo.example", "name": "Bob Foo"}}}'],
+                         key_field=['user.pii.username'],
+                         )
+        mocked_client.Stream.assert_called_once_with('dev-test')
+        # Actual event producing is tested elsewhere, this is just to make sure the command produces *something*
+        stream_mock.add.assert_called_once()
+        assert stream_mock.add.call_args.args[0]["event_data"] == b'value-bytes-here'
+        fake_logger.exception.assert_not_called()

--- a/edx_event_bus_redis/internal/utils.py
+++ b/edx_event_bus_redis/internal/utils.py
@@ -57,8 +57,6 @@ HEADER_TIME = MessageHeader("time", event_metadata_field="time",
                             from_metadata=lambda x: x.isoformat())
 HEADER_MINORVERSION = MessageHeader("minorversion", event_metadata_field="minorversion", to_metadata=int,
                                     from_metadata=str)
-
-# not CloudEvent headers, so no "ce" prefix
 HEADER_SOURCEHOST = MessageHeader("sourcehost", event_metadata_field="sourcehost")
 HEADER_SOURCELIB = MessageHeader("sourcelib", event_metadata_field="sourcelib",
                                  to_metadata=_sourcelib_str_to_tuple, from_metadata=_sourcelib_tuple_to_str)
@@ -75,7 +73,6 @@ def get_message_header_values(headers: List, header: MessageHeader) -> List[str]
     Returns:
         List of zero or more header values decoded as strings.
     """
-    # CloudEvents specifies using UTF-8 for header values, so let's be explicit.
     return [value.decode("utf-8") for key, value in headers if key == header.message_header_key]
 
 
@@ -156,7 +153,7 @@ def get_headers_from_metadata(event_metadata: oed.EventsMetadata):
         if not header.event_metadata_field:
             continue
         event_metadata_value = getattr(event_metadata, header.event_metadata_field)
-        # CloudEvents specifies using UTF-8; that should be the default, but let's make it explicit.
+        # Convert string to utf8 encoded bytes
         values[header.message_header_key] = header.from_metadata(event_metadata_value).encode("utf8")
 
     return values

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django             # Web application framework
-openedx-events>=5.0.0                   # Events API
+openedx-events>=7.0.0                   # Use serialize & deserialize utility
 edx_django_utils
 edx_toggles
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ edx-opaque-keys[django]==2.3.0
     # via openedx-events
 edx-toggles==5.0.0
     # via -r requirements/base.in
-fastavro==1.7.2
+fastavro==1.7.3
     # via openedx-events
 jinja2==3.1.2
     # via code-annotations
@@ -50,7 +50,7 @@ markupsafe==2.1.2
     # via jinja2
 newrelic==8.7.0
     # via edx-django-utils
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore
@@ -62,7 +62,7 @@ pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via code-annotations
 pytz==2022.7.1
     # via django

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,11 +6,11 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==7.2.0
+coverage==7.2.1
     # via codecov
 distlib==0.3.6
     # via virtualenv
@@ -22,7 +22,7 @@ idna==3.4
     # via requests
 packaging==23.0
     # via tox
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -43,5 +43,5 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 urllib3==1.26.14
     # via requests
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.14.2
+astroid==2.15.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -36,7 +36,7 @@ cffi==1.15.1
     #   pynacl
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/ci.txt
     #   requests
@@ -60,7 +60,7 @@ code-annotations==1.3.0
     #   edx-toggles
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -115,7 +115,7 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   -r requirements/quality.txt
     #   openedx-events
@@ -157,7 +157,7 @@ newrelic==8.7.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via -r requirements/quality.txt
 packaging==23.0
     # via
@@ -173,9 +173,9 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.12.2
+pip-tools==6.12.3
     # via -r requirements/pip-tools.txt
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -208,7 +208,7 @@ pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.14.0
     # via diff-cover
-pylint==2.16.2
+pylint==2.17.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -240,7 +240,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -249,7 +249,7 @@ pytest-cov==4.0.0
     # via -r requirements/quality.txt
 pytest-django==4.5.2
     # via -r requirements/quality.txt
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -325,7 +325,7 @@ urllib3==1.26.14
     # via
     #   -r requirements/ci.txt
     #   requests
-virtualenv==20.19.0
+virtualenv==20.20.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -335,7 +335,7 @@ wheel==0.38.4
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -r requirements/quality.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.3
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 asgiref==3.6.0
@@ -19,8 +21,10 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   openedx-events
     #   pytest
-babel==2.11.0
-    # via sphinx
+babel==2.12.1
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 beautifulsoup4==4.11.2
     # via pydata-sphinx-theme
 bleach==6.0.0
@@ -34,7 +38,7 @@ cffi==1.15.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -45,11 +49,11 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.1
+cryptography==39.0.2
     # via secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
@@ -71,7 +75,7 @@ django-waffle==3.0.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
-docutils==0.17.1
+docutils==0.19
     # via
     #   pydata-sphinx-theme
     #   readme-renderer
@@ -90,7 +94,7 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -130,13 +134,13 @@ markupsafe==2.1.2
     #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
 newrelic==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -163,10 +167,12 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.8.1
+pydata-sphinx-theme==0.13.1
     # via sphinx-book-theme
 pygments==2.14.0
     # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
     #   readme-renderer
     #   rich
     #   sphinx
@@ -180,7 +186,7 @@ pynacl==1.5.0
     #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -189,7 +195,7 @@ pytest-cov==4.0.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -202,7 +208,6 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-    #   sphinx-book-theme
 readme-renderer==37.3
     # via twine
 redis==4.5.1
@@ -218,7 +223,7 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.1
+rich==13.3.2
     # via twine
 secretstorage==3.3.3
     # via keyring
@@ -228,13 +233,13 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.4
     # via beautifulsoup4
-sphinx==4.5.0
+sphinx==5.3.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==0.3.3
+sphinx-book-theme==1.0.0
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -281,7 +286,7 @@ walrus==0.9.2
     # via -r requirements/test.txt
 webencodings==0.5.1
     # via bleach
-zipp==3.14.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.3
     # via pip-tools
 packaging==23.0
     # via build
-pip-tools==6.12.2
+pip-tools==6.12.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.38.4
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.4.0
+setuptools==67.6.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.14.2
+astroid==2.15.0
     # via
     #   pylint
     #   pylint-celery
@@ -39,7 +39,7 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -81,7 +81,7 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -109,7 +109,7 @@ newrelic==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -119,7 +119,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.0.0
+platformdirs==3.1.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -137,7 +137,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.16.2
+pylint==2.17.0
     # via
     #   edx-lint
     #   pylint-celery
@@ -159,7 +159,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -168,7 +168,7 @@ pytest-cov==4.0.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -216,5 +216,5 @@ typing-extensions==4.5.0
     #   pylint
 walrus==0.9.2
     # via -r requirements/test.txt
-wrapt==1.14.1
+wrapt==1.15.0
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -31,7 +31,7 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==7.2.0
+coverage[toml]==7.2.1
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -64,7 +64,7 @@ edx-toggles==5.0.0
     # via -r requirements/base.txt
 exceptiongroup==1.1.0
     # via pytest
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   -r requirements/base.txt
     #   openedx-events
@@ -82,7 +82,7 @@ newrelic==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==5.1.0
+openedx-events==7.0.0
     # via -r requirements/base.txt
 packaging==23.0
     # via pytest
@@ -108,7 +108,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   pytest-cov
     #   pytest-django
@@ -116,7 +116,7 @@ pytest-cov==4.0.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
-python-slugify==8.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations


### PR DESCRIPTION
**Description:**
Adds functionality to send events to redis streams.

**JIRA:** `Private-ref`: [BB-7180](https://tasks.opencraft.com/browse/BB-7180)
**Issue**: #4 

**Dependencies:** https://github.com/openedx/openedx-events/pull/189

**Merge deadline:** List merge deadline (if any)

**Testing instructions:**

**Test via edx-platflorm**

- Make sure to update your devstack to latest master. `make lms-pull studio-pull`  
- Run `make lms-up studio-up redis-up` to start lms, studio and redis.  
- Open studio shell using `make studio-shell`  
- Clone this repo under `<devstack_base_dir>/src/event-bus-redis` and checkout this MR.  
- Run `pip install -e /edx/src/event-bus-redis` to install this repo.  
- Add below snippet to `cms/envs/private.py`  
  ``` python
  from .common import FEATURES
  FEATURES['ENABLE_SEND_XBLOCK_EVENTS_OVER_BUS'] = True
  EVENT_BUS_TOPIC_PREFIX = 'dev'
  EVENT_BUS_PRODUCER = 'edx_event_bus_redis.create_producer'
  EVENT_BUS_REDIS_CONNECTION_URL = 'redis://:password@edx.devstack.redis:6379/'
  ```
- Restart studio using `make restart-studio`  
- Create a file `test_redis_event.py` anywhere inside studio-shell.  
- Add below snippet to it.  
  ``` python
  from walrus import Database
  client = Database.from_url("redis://:password@edx.devstack.redis:6379/")
  stream = client.Stream('dev-xblock-deleted')
  print(stream.read(block=0, last_id='$'))
  ```
- Run the file using `python test_redis_event.py`, this will wait for a xblock deleted event and print it if triggered.
- *Optional* In another terminal run `make studio-logs` to see the event logs.  
- In studio UI, delete any xblock in any course, a xblock-deleted event should be published and printed in the first terminal.  
  ``` log
  root@studio:/edx/app/edxapp/edx-platform# python test_redis_event.py
  [(b'1677741833282-0', {b'event_data': b'\x9e\x01block-v1:edX+DemoX+Demo_Course+type@html+block@6bcccc2d7343416e9e03fd7325b2f232\x08html', b'type': b'org.openedx.content_authoring.xblock.deleted.v1', b'id': b'2f767544-b8cb-11ed-a87d-0242ac13000b', b'source': b'openedx/cms/web', b'time': b'2023-03-02T07:23:53.251709+00:00', b'minorversion': b'0', b'sourcehost': b'studio.devstack.edx', b'sourcelib': b'5.1.0'})]
  ```

**Test produce_event command**  

- Run redis server locally  
- Add below snippet to `test_settings.py`  
  ``` python
  EVENT_BUS_PRODUCER = 'edx_event_bus_redis.create_producer'
  EVENT_BUS_REDIS_CONNECTION_URL = 'redis://:password@localhost:6379/'
  ```
- Run below snippet in a python shell or via python file, it will wait for an event and print it.  
  ``` python
  from walrus import Database
  client = Database.from_url("redis://:password@edx.devstack.redis:6379/")
  stream = client.Stream('dev-xblock-deleted')
  print(stream.read(block=0, last_id='$'))
  ```
- Finally run the management command  
  ``` shell
  python manage.py produce_event --signal openedx_events.content_authoring.signals.XBLOCK_DELETED --topic dev-xblock-deleted --key-field None --data '{"xblock_info": {"usage_key": "some", "block_type": "video"}}'
  ```
  The event should be printed in previous shell.

**Reviewers:**
- [x] @keithgg

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
