### PR TITLE
feat: make use of abstract consumer API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,11 @@ Unreleased
 
 *
 
-[0.1.0] - 2023-02-22
+[0.1.0] - 2023-05-04
 ************************************************
 
 Added
 =====
 
 * First release on PyPI.
+* Redis streams consumer and producer implemented.

--- a/Makefile
+++ b/Makefile
@@ -118,14 +118,14 @@ produce_test_event:
 	EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py produce_event --signal openedx_events.content_authoring.signals.XBLOCK_DELETED --topic xblock-deleted --key-field None --data '{"xblock_info": {"usage_key": "block-v1:edx+DemoX+Demo_course+type@video+block@UaEBjyMjcLW65gaTXggB93WmvoxGAJa0JeHRrDThk", "block_type": "video"}}'
 
 consume_test_event:
-	EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --consumer_name test_group.c1
+	EVENT_BUS_CONSUMER='edx_event_bus_redis.RedisEventConsumer' EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --extra '{"consumer_name": "test_group.c1"}'
 
 multiple_consumer_test_event:
-	EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --consumer_name test_group.c1 &
-	EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --consumer_name test_group.c2 &
+	EVENT_BUS_CONSUMER='edx_event_bus_redis.RedisEventConsumer' EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --extra '{"consumer_name": "test_group.c1"}' &
+	EVENT_BUS_CONSUMER='edx_event_bus_redis.RedisEventConsumer' EVENT_BUS_PRODUCER='edx_event_bus_redis.create_producer' EVENT_BUS_REDIS_CONNECTION_URL='redis://:password@localhost:6379/' EVENT_BUS_TOPIC_PREFIX='dev' python manage.py consume_events --signal org.openedx.content_authoring.xblock.deleted.v1 --topic xblock-deleted --group_id test_group --extra '{"consumer_name": "test_group.c2"}' &
 
 kill_all_consume_test_events:
-	pgrep -lf python\ manage.py\ consume_events\ --signal\ org.openedx.content_authoring.xblock.deleted.v1\ --topic\ xblock-deleted\ --group_id\ test_group\ --consumer_name\ test_group. | cut -d" " -f1 | xargs kill -15
+	pgrep -lf python\ manage.py\ consume_events\ --signal\ org.openedx.content_authoring.xblock.deleted.v1\ --topic\ xblock-deleted\ --group_id\ test_group | cut -d" " -f1 | xargs kill -15
 
 redis-up:
 	docker compose up

--- a/edx_event_bus_redis/__init__.py
+++ b/edx_event_bus_redis/__init__.py
@@ -2,6 +2,7 @@
 Redis Streams implementation for the Open edX event bus.
 """
 
+from edx_event_bus_redis.internal.consumer import RedisEventConsumer
 from edx_event_bus_redis.internal.producer import create_producer
 
 __version__ = '0.1.0'

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -98,11 +98,11 @@ class RedisEventConsumer(EventBusConsumer):
         consumer: consumer instance.
     """
 
-    def __init__(self, topic, group_id, signal, consumer_name=None, last_read_msg_id=None, check_backlog=False):
+    def __init__(self, topic, group_id, signal, consumer_name, last_read_msg_id=None, check_backlog=False):
         self.topic = topic
         self.group_id = group_id
         self.signal = signal
-        self.consumer_name = consumer_name or (self.group_id + '.c1')
+        self.consumer_name = consumer_name
         self.last_read_msg_id = last_read_msg_id
         self.check_backlog = check_backlog
         self.db = self._create_db()

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -6,12 +6,12 @@ import time
 from typing import Optional
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
 from django.db import connection
 from edx_django_utils.monitoring import record_exception, set_custom_attribute
 from edx_toggles.toggles import SettingToggle
+from openedx_events.event_bus import EventBusConsumer
 from openedx_events.event_bus.avro.deserializer import deserialize_bytes_to_event_data
-from openedx_events.tooling import OpenEdxPublicSignal, load_all_signals
+from openedx_events.tooling import OpenEdxPublicSignal
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import ResponseError
 from walrus import Database
@@ -77,7 +77,7 @@ def _reconnect_to_db_if_needed():
         connection.connect()
 
 
-class RedisEventConsumer:
+class RedisEventConsumer(EventBusConsumer):
     """
     Construct consumer for the given topic, group, and signal. The consumer can then
     emit events from the event bus using the configured signal.
@@ -85,6 +85,17 @@ class RedisEventConsumer:
     Note that the topic should be specified here *without* the optional environment prefix.
 
     Can also consume messages indefinitely off the queue.
+
+    Attributes:
+        topic: Topic/stream name.
+        group_id: consumer group name.
+        signal: openedx_events signal.
+        consumer_name: unique name for consumer within a group.
+        last_read_msg_id: Start reading msgs from a specific redis msg id.
+        check_backlog: flag to process all messages that were not read by this consumer group.
+        db: Walrus object for redis connection.
+        full_topic: topic prefixed with environment name.
+        consumer: consumer instance.
     """
 
     def __init__(self, topic, group_id, signal, consumer_name=None, last_read_msg_id=None, check_backlog=False):
@@ -154,8 +165,6 @@ class RedisEventConsumer:
         Consume events from a topic in an infinite loop.
         """
 
-        # This is already checked at the Command level, but it's possible this loop
-        # could get called some other way, so check it here too.
         if not REDIS_CONSUMERS_ENABLED.is_enabled():
             logger.error("Redis consumers not enabled, exiting.")
             return
@@ -420,87 +429,3 @@ class RedisEventConsumer:
             return True
 
         return False
-
-
-class ConsumeEventsCommand(BaseCommand):
-    """
-    Management command for Redis consumer workers in the event bus.
-    """
-    help = """
-    Consume messages of specified signal type from a Redis topic/stream and send their data to that signal.
-
-    Example::
-
-        python3 manage.py cms consume_events -t user-login -g user-activity-service \
-            -s org.openedx.learning.auth.session.login.completed.v1
-
-        # process unread messages from the topic by this consumer group.
-        python3 manage.py cms consume_events -t user-login -g user-activity-service \
-            -s org.openedx.learning.auth.session.login.completed.v1 --check_backlog
-
-        # replay events from specific redis msg id.
-        python3 manage.py cms consume_events -t user-login -g user-activity-service \
-            -s org.openedx.learning.auth.session.login.completed.v1 \
-            --last_read_msg_id 1679676448892-0
-    """
-
-    def add_arguments(self, parser):
-
-        parser.add_argument(
-            '-t', '--topic',
-            nargs=1,
-            required=True,
-            help='Topic to consume (without environment prefix)'
-        )
-
-        parser.add_argument(
-            '-g', '--group_id',
-            nargs=1,
-            required=True,
-            help='Consumer group id'
-        )
-        parser.add_argument(
-            '-s', '--signal',
-            nargs=1,
-            required=True,
-            help='Type of signal to emit from consumed messages.'
-        )
-        parser.add_argument(
-            '-b', '--check_backlog',
-            action='store_true',
-            help='Process unread messages'
-        )
-        parser.add_argument(
-            '-i', '--last_read_msg_id',
-            nargs='?',
-            required=False,
-            default=None,
-            help='Replay events from this redis msg id. For example: 1679676448892-0'
-        )
-        parser.add_argument(
-            '-n', '--consumer_name',
-            nargs='?',
-            required=False,
-            default=None,
-            help='Unique name for this consumer instance.'
-        )
-
-    def handle(self, *args, **options):
-        if not REDIS_CONSUMERS_ENABLED.is_enabled():
-            logger.error("Redis consumers not enabled, exiting.")
-            return
-
-        try:
-            load_all_signals()
-            signal = OpenEdxPublicSignal.get_signal_by_type(options['signal'][0])
-            event_consumer = RedisEventConsumer(
-                topic=options['topic'][0],
-                group_id=options['group_id'][0],
-                signal=signal,
-                consumer_name=options['consumer_name'],
-                last_read_msg_id=options['last_read_msg_id'],
-                check_backlog=options['check_backlog'],
-            )
-            event_consumer.consume_indefinitely()
-        except Exception:  # pylint: disable=broad-except
-            logger.exception("Error consuming Redis events")

--- a/edx_event_bus_redis/internal/tests/test_consumer.py
+++ b/edx_event_bus_redis/internal/tests/test_consumer.py
@@ -81,6 +81,7 @@ class TestConsumer(TestCase):
                 'local-some-topic',
                 'test_group_id',
                 self.signal,
+                consumer_name='test_group_id.c1',
                 check_backlog=True
             )
 
@@ -124,6 +125,7 @@ class TestConsumer(TestCase):
                 'local-some-topic',
                 'test_group_id',
                 self.signal,
+                consumer_name='test_group_id.c1',
                 last_read_msg_id=last_read_msg_id,
                 check_backlog=check_backlog,
             )
@@ -406,7 +408,7 @@ class TestConsumer(TestCase):
     @override_settings(EVENT_BUS_REDIS_CONNECTION_URL=None)
     def test_missing_url_setting(self):
         with pytest.raises(ValueError, match="Missing"):
-            RedisEventConsumer('local-some-topic', 'test_group_id', self.signal)
+            RedisEventConsumer('local-some-topic', 'test_group_id', self.signal, 'test_group_id.c1')
 
     @override_settings(
         EVENT_BUS_TOPIC_PREFIX='local',

--- a/edx_event_bus_redis/management/commands/consume_events.py
+++ b/edx_event_bus_redis/management/commands/consume_events.py
@@ -1,5 +1,0 @@
-"""
-Makes ``consume_events`` management command available.
-"""
-
-from edx_event_bus_redis.internal.consumer import ConsumeEventsCommand as Command  # pylint: disable=unused-import

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 -c constraints.txt
 
 Django             # Web application framework
-openedx-events>=7.0.0                   # Use serialize & deserialize utility
+openedx-events>=7.1.0                   # consumer api and consume_events provided
 edx_django_utils
 edx_toggles
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,7 +50,7 @@ markupsafe==2.1.2
     # via jinja2
 newrelic==8.8.0
     # via edx-django-utils
-openedx-events==7.0.0
+git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via django
 async-timeout==4.0.2
     # via redis
-attrs==22.2.0
+attrs==23.1.0
     # via openedx-events
 cffi==1.15.1
     # via pynacl
@@ -18,7 +18,7 @@ click==8.1.3
     #   edx-django-utils
 code-annotations==1.3.0
     # via edx-toggles
-django==3.2.18
+django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -50,11 +50,11 @@ markupsafe==2.1.2
     # via jinja2
 newrelic==8.8.0
     # via edx-django-utils
-git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
+openedx-events==7.1.0
     # via -r requirements/base.in
 pbr==5.11.1
     # via stevedore
-psutil==5.9.4
+psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -70,7 +70,7 @@ pyyaml==6.0
     # via code-annotations
 redis==4.5.4
     # via walrus
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 stevedore==5.0.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,13 +6,13 @@
 #
 distlib==0.3.6
     # via virtualenv
-filelock==3.11.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -29,5 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.2
+astroid==2.15.4
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -17,7 +17,7 @@ async-timeout==4.0.2
     # via
     #   -r requirements/quality.txt
     #   redis
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/quality.txt
     #   openedx-events
@@ -49,7 +49,7 @@ code-annotations==1.3.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -65,7 +65,7 @@ distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.18
+django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -106,7 +106,7 @@ fastavro==1.7.3
     # via
     #   -r requirements/quality.txt
     #   openedx-events
-filelock==3.11.0
+filelock==3.12.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -140,7 +140,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
+openedx-events==7.1.0
     # via -r requirements/quality.txt
 packaging==23.1
     # via
@@ -158,7 +158,7 @@ pbr==5.11.1
     #   stevedore
 pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -173,7 +173,7 @@ pluggy==1.0.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -189,9 +189,9 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.15.0
+pygments==2.15.1
     # via diff-cover
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -223,7 +223,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -259,7 +259,7 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/quality.txt
     #   django
@@ -284,7 +284,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -300,7 +300,7 @@ typing-extensions==4.5.0
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -140,7 +140,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events==7.0.0
+git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
     # via -r requirements/quality.txt
 packaging==23.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -132,7 +132,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==7.0.0
+git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,7 +16,7 @@ async-timeout==4.0.2
     # via
     #   -r requirements/test.txt
     #   redis
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -35,6 +35,7 @@ certifi==2022.12.7
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
+    #   cryptography
     #   pynacl
 charset-normalizer==3.1.0
     # via requests
@@ -47,13 +48,15 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
+cryptography==40.0.2
+    # via secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
-django==3.2.18
+django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -98,7 +101,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.3.0
+importlib-metadata==6.6.0
     # via
     #   keyring
     #   sphinx
@@ -111,6 +114,10 @@ iniconfig==2.0.0
     #   pytest
 jaraco-classes==3.2.3
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -132,7 +139,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
+openedx-events==7.1.0
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -151,7 +158,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -161,7 +168,7 @@ pycparser==2.21
     #   cffi
 pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
-pygments==2.15.0
+pygments==2.15.1
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
@@ -178,7 +185,7 @@ pynacl==1.5.0
     #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -206,22 +213,24 @@ redis==4.5.4
     # via
     #   -r requirements/test.txt
     #   walrus
-requests==2.28.2
+requests==2.29.0
     # via
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.4
+rich==13.3.5
     # via twine
+secretstorage==3.3.3
+    # via keyring
 six==1.16.0
     # via bleach
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
 sphinx==5.3.0
     # via
@@ -243,7 +252,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==67.6.1
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.2
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
@@ -16,7 +16,7 @@ async-timeout==4.0.2
     # via
     #   -r requirements/test.txt
     #   redis
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -38,7 +38,7 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -46,7 +46,7 @@ ddt==1.6.0
     # via -r requirements/test.txt
 dill==0.3.6
     # via pylint
-django==3.2.18
+django==3.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -108,7 +108,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
+openedx-events==7.1.0
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -118,13 +118,13 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via pylint
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -136,7 +136,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -158,7 +158,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -187,7 +187,7 @@ six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
@@ -207,7 +207,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -108,7 +108,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==7.0.0
+git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
     # via -r requirements/test.txt
 packaging==23.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ async-timeout==4.0.2
     # via
     #   -r requirements/base.txt
     #   redis
-attrs==22.2.0
+attrs==23.1.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
@@ -30,7 +30,7 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -81,7 +81,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
+openedx-events==7.1.0
     # via -r requirements/base.txt
 packaging==23.1
     # via pytest
@@ -91,7 +91,7 @@ pbr==5.11.1
     #   stevedore
 pluggy==1.0.0
     # via pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -107,7 +107,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -131,7 +131,7 @@ redis==4.5.4
     # via
     #   -r requirements/base.txt
     #   walrus
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -81,7 +81,7 @@ newrelic==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==7.0.0
+git+https://github.com/open-craft/openedx-events.git@navin/load-consumer
     # via -r requirements/base.txt
 packaging==23.1
     # via pytest

--- a/test_settings.py
+++ b/test_settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.sessions',
     'edx_event_bus_redis',
+    'openedx_events',
 )
 
 LOCALE_PATHS = [
@@ -81,3 +82,4 @@ TEMPLATES = [{
 EVENT_BUS_PRODUCER = getenv('EVENT_BUS_PRODUCER')
 EVENT_BUS_REDIS_CONNECTION_URL = getenv('EVENT_BUS_REDIS_CONNECTION_URL')
 EVENT_BUS_TOPIC_PREFIX = getenv('EVENT_BUS_TOPIC_PREFIX')
+EVENT_BUS_CONSUMER = getenv('EVENT_BUS_CONSUMER')


### PR DESCRIPTION
**Description:** Removes local `consume_events` command and instead makes use of new abstract consumer API and the command from openedx-events to start a worker.

**JIRA:** `Private-ref`: [BB-7240](https://tasks.opencraft.com/browse/BB-7240)

**Issue:** https://github.com/openedx/openedx-events/issues/147

**Dependencies:** https://github.com/openedx/openedx-events/pull/200

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** and **Testing instructions:**

Follow [instructions from readme](https://github.com/openedx/event-bus-redis#testing-locally). The `consume_events` command is provided by openedx-events and the `RedisEventConsumer` is loaded from `test_settings.EVENT_BUS_CONSUMER`.

**Reviewers:**
- [x] @kaustavb12
- [ ] @bmtcril

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
