### PR TITLE
chore: Remove broken codecov dependency, run upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,7 +34,7 @@ django-waffle==3.0.0
     # via
     #   edx-django-utils
     #   edx-toggles
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-toggles
@@ -48,7 +48,7 @@ jinja2==3.1.2
     # via code-annotations
 markupsafe==2.1.2
     # via jinja2
-newrelic==8.7.0
+newrelic==8.8.0
     # via edx-django-utils
 openedx-events==7.0.0
     # via -r requirements/base.in
@@ -64,11 +64,11 @@ pynacl==1.5.0
     # via edx-django-utils
 python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via django
 pyyaml==6.0
     # via code-annotations
-redis==4.5.1
+redis==4.5.4
     # via walrus
 sqlparse==0.4.3
     # via django

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,32 +4,20 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.1
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.9.0
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
-packaging==23.0
+packaging==23.1
     # via tox
-platformdirs==3.1.0
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -41,7 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.14
-    # via requests
-virtualenv==20.20.0
+virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -21,25 +21,16 @@ attrs==22.2.0
     # via
     #   -r requirements/quality.txt
     #   openedx-events
-    #   pytest
 build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.12.7
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 cffi==1.15.1
     # via
     #   -r requirements/quality.txt
     #   pynacl
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==3.1.0
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 click==8.1.3
     # via
     #   -r requirements/pip-tools.txt
@@ -58,13 +49,9 @@ code-annotations==1.3.0
     #   -r requirements/quality.txt
     #   edx-lint
     #   edx-toggles
-codecov==2.1.12
-    # via -r requirements/ci.txt
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 ddt==1.6.0
     # via -r requirements/quality.txt
@@ -97,13 +84,13 @@ django-waffle==3.0.0
     #   -r requirements/quality.txt
     #   edx-django-utils
     #   edx-toggles
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-toggles
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/quality.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -111,7 +98,7 @@ edx-opaque-keys[django]==2.3.0
     #   openedx-events
 edx-toggles==5.0.0
     # via -r requirements/quality.txt
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -119,15 +106,11 @@ fastavro==1.7.3
     # via
     #   -r requirements/quality.txt
     #   openedx-events
-filelock==3.9.0
+filelock==3.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-idna==3.4
-    # via
-    #   -r requirements/ci.txt
-    #   requests
 iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
@@ -153,13 +136,13 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
 openedx-events==7.0.0
     # via -r requirements/quality.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -173,9 +156,9 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.1.0
+platformdirs==3.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -206,9 +189,9 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.0
     # via diff-cover
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -240,7 +223,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -253,7 +236,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   django
@@ -262,14 +245,10 @@ pyyaml==6.0
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-i18n-tools
-redis==4.5.1
+redis==4.5.4
     # via
     #   -r requirements/quality.txt
     #   walrus
-requests==2.28.2
-    # via
-    #   -r requirements/ci.txt
-    #   codecov
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -305,7 +284,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -321,17 +300,13 @@ typing-extensions==4.5.0
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.14
-    # via
-    #   -r requirements/ci.txt
-    #   requests
-virtualenv==20.20.0
+virtualenv==20.21.0
     # via
     #   -r requirements/ci.txt
     #   tox
 walrus==0.9.2
     # via -r requirements/quality.txt
-wheel==0.38.4
+wheel==0.40.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-accessible-pygments==0.0.3
+accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
@@ -20,12 +20,11 @@ attrs==22.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-    #   pytest
 babel==2.12.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 bleach==6.0.0
     # via readme-renderer
@@ -36,7 +35,6 @@ certifi==2022.12.7
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.1.0
     # via requests
@@ -49,12 +47,10 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.2
-    # via secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
 django==3.2.18
@@ -80,7 +76,7 @@ docutils==0.19
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
@@ -90,7 +86,7 @@ edx-opaque-keys[django]==2.3.0
     #   openedx-events
 edx-toggles==5.0.0
     # via -r requirements/test.txt
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -102,7 +98,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.3.0
     # via
     #   keyring
     #   sphinx
@@ -115,10 +111,6 @@ iniconfig==2.0.0
     #   pytest
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -136,13 +128,13 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 openedx-events==7.0.0
     # via -r requirements/test.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   build
@@ -167,9 +159,9 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.13.1
+pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
@@ -186,7 +178,7 @@ pynacl==1.5.0
     #   edx-django-utils
 pyproject-hooks==1.0.0
     # via build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -199,7 +191,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel
@@ -210,7 +202,7 @@ pyyaml==6.0
     #   code-annotations
 readme-renderer==37.3
     # via twine
-redis==4.5.1
+redis==4.5.4
     # via
     #   -r requirements/test.txt
     #   walrus
@@ -223,10 +215,8 @@ requests-toolbelt==0.10.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==13.3.2
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via bleach
 snowballstemmer==2.2.0
@@ -239,7 +229,7 @@ sphinx==5.3.0
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.0.0
+sphinx-book-theme==1.0.1
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -277,8 +267,10 @@ tomli==2.0.1
 twine==4.0.2
     # via -r requirements/doc.in
 typing-extensions==4.5.0
-    # via rich
-urllib3==1.26.14
+    # via
+    #   pydata-sphinx-theme
+    #   rich
+urllib3==1.26.15
     # via
     #   requests
     #   twine

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,15 +8,15 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
     # via build
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.0.1
     # via -r requirements/pip.in
-setuptools==67.6.0
+setuptools==67.6.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
@@ -20,7 +20,6 @@ attrs==22.2.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-    #   pytest
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
@@ -39,7 +38,7 @@ code-annotations==1.3.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -65,11 +64,11 @@ django-waffle==3.0.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-toggles
-edx-lint==5.3.2
+edx-lint==5.3.4
     # via -r requirements/quality.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -77,7 +76,7 @@ edx-opaque-keys[django]==2.3.0
     #   openedx-events
 edx-toggles==5.0.0
     # via -r requirements/test.txt
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -105,13 +104,13 @@ markupsafe==2.1.2
     #   jinja2
 mccabe==0.7.0
     # via pylint
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
 openedx-events==7.0.0
     # via -r requirements/test.txt
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -119,7 +118,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.1.0
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -137,7 +136,7 @@ pycparser==2.21
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.0
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -159,7 +158,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -172,7 +171,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -180,7 +179,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-redis==4.5.1
+redis==4.5.4
     # via
     #   -r requirements/test.txt
     #   walrus
@@ -208,7 +207,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,6 @@ attrs==22.2.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
-    #   pytest
 cffi==1.15.1
     # via
     #   -r requirements/base.txt
@@ -31,7 +30,7 @@ code-annotations==1.3.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-toggles
-coverage[toml]==7.2.1
+coverage[toml]==7.2.3
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -52,7 +51,7 @@ django-waffle==3.0.0
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-toggles
-edx-django-utils==5.2.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
@@ -62,7 +61,7 @@ edx-opaque-keys[django]==2.3.0
     #   openedx-events
 edx-toggles==5.0.0
     # via -r requirements/base.txt
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 fastavro==1.7.3
     # via
@@ -78,13 +77,13 @@ markupsafe==2.1.2
     # via
     #   -r requirements/base.txt
     #   jinja2
-newrelic==8.7.0
+newrelic==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
 openedx-events==7.0.0
     # via -r requirements/base.txt
-packaging==23.0
+packaging==23.1
     # via pytest
 pbr==5.11.1
     # via
@@ -108,7 +107,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-cov
     #   pytest-django
@@ -120,7 +119,7 @@ python-slugify==8.0.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django
@@ -128,7 +127,7 @@ pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
-redis==4.5.1
+redis==4.5.4
     # via
     #   -r requirements/base.txt
     #   walrus


### PR DESCRIPTION
Description: codecov pulled their entire PyPI project and everything broke. We didn't actually need it, since we're using the Github action to upload these days. Also running make upgrade to propagate the change.