### PR TITLE
feat: claim pending messages from other consumers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,19 @@ Unreleased
 
 *
 
+[0.1.1] - 2023-05-12
+************************************************
+
+Added
+=====
+
+* Option to claim messages from other consumers based on idle time.
+
+Changed
+=======
+
+* Setting ``check_backlog`` will read messages that were not read by this consumer group.
+
 [0.1.0] - 2023-05-04
 ************************************************
 

--- a/edx_event_bus_redis/__init__.py
+++ b/edx_event_bus_redis/__init__.py
@@ -5,6 +5,6 @@ Redis Streams implementation for the Open edX event bus.
 from edx_event_bus_redis.internal.consumer import RedisEventConsumer
 from edx_event_bus_redis.internal.producer import create_producer
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 default_app_config = 'edx_event_bus_redis.apps.EdxEventBusRedisConfig'  # pylint: disable=invalid-name

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -93,18 +93,24 @@ class RedisEventConsumer(EventBusConsumer):
         consumer_name: unique name for consumer within a group.
         last_read_msg_id: Start reading msgs from a specific redis msg id.
         check_backlog: flag to process all messages that were not read by this consumer group.
+        claim_msgs_older_than: claim pending msgs from other consumers in the group with idle time older
+        than a specific time (in milliseconds).
+        has_pending_msgs: flag to process pending msgs first.
         db: Walrus object for redis connection.
         full_topic: topic prefixed with environment name.
         consumer: consumer instance.
     """
 
-    def __init__(self, topic, group_id, signal, consumer_name, last_read_msg_id=None, check_backlog=False):
+    def __init__(self, topic, group_id, signal, consumer_name, last_read_msg_id=None, check_backlog=False,
+                 claim_msgs_older_than=None):
         self.topic = topic
         self.group_id = group_id
         self.signal = signal
         self.consumer_name = consumer_name
         self.last_read_msg_id = last_read_msg_id
         self.check_backlog = check_backlog
+        self.has_pending_msgs = True
+        self.claim_msgs_older_than = claim_msgs_older_than
         self.db = self._create_db()
         self.full_topic = get_full_topic(self.topic)
         self.consumer = self._create_consumer(self.db, self.full_topic)
@@ -153,10 +159,13 @@ class RedisEventConsumer(EventBusConsumer):
         Read pending messages, if no messages found set check_backlog to False.
         """
         logger.debug("Consuming pending msgs first.")
+        if self.claim_msgs_older_than is not None:
+            self.consumer.autoclaim(self.consumer_name, min_idle_time=self.claim_msgs_older_than, count=1)
         msg_meta = self.consumer.pending(count=1, consumer=self.consumer_name)
         if not msg_meta:
             logger.debug("No more pending messages.")
-            self.check_backlog = False
+            self.has_pending_msgs = False
+            self.claim_msgs_older_than = None
             return None
         return self.consumer[msg_meta[0]['message_id']]
 
@@ -215,7 +224,7 @@ class RedisEventConsumer(EventBusConsumer):
                 try:
                     # The first time we want to read our pending messages, in case we crashed and are recovering.
                     # Once we consumed our history, we can start getting new messages.
-                    if self.check_backlog:
+                    if self.has_pending_msgs:
                         redis_raw_msg = self._read_pending_msgs()
                     else:
                         # poll for msg

--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 REDIS_CONSUMERS_ENABLED = SettingToggle('EVENT_BUS_REDIS_CONSUMERS_ENABLED', default=True)
 
 # .. setting_name: EVENT_BUS_REDIS_CONSUMER_POLL_TIMEOUT
-# .. setting_default: 1.0
+# .. setting_default: 1
 # .. setting_description: How long the consumer should wait, in seconds, for the Redis broker
 #   to respond to a poll() call.
 CONSUMER_POLL_TIMEOUT = getattr(settings, 'EVENT_BUS_REDIS_CONSUMER_POLL_TIMEOUT', 1)
@@ -94,7 +94,7 @@ class RedisEventConsumer(EventBusConsumer):
         last_read_msg_id: Start reading msgs from a specific redis msg id.
         check_backlog: flag to process all messages that were not read by this consumer group.
         claim_msgs_older_than: claim pending msgs from other consumers in the group with idle time older
-        than a specific time (in milliseconds).
+            than a specific time (in milliseconds).
         has_pending_msgs: flag to process pending msgs first.
         db: Walrus object for redis connection.
         full_topic: topic prefixed with environment name.
@@ -109,6 +109,7 @@ class RedisEventConsumer(EventBusConsumer):
         self.consumer_name = consumer_name
         self.last_read_msg_id = last_read_msg_id
         self.check_backlog = check_backlog
+        # always process read but pending msgs first for the consumer in the group.
         self.has_pending_msgs = True
         self.claim_msgs_older_than = claim_msgs_older_than
         self.db = self._create_db()
@@ -156,7 +157,7 @@ class RedisEventConsumer(EventBusConsumer):
 
     def _read_pending_msgs(self) -> Optional[tuple]:
         """
-        Read pending messages, if no messages found set check_backlog to False.
+        Read pending messages, if no messages found set has_pending_msgs to False.
         """
         logger.debug("Consuming pending msgs first.")
         if self.claim_msgs_older_than is not None:


### PR DESCRIPTION
Mirror of https://github.com/open-craft/event-bus-redis/pull/1 as github does not allow changing PRs across forks.