### PR TITLE
feat: make signal argument optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Unreleased
 
 *
 
+[0.2.1] - 2023-05-12
+************************************************
+
+Changed
+=======
+* Deprecated ``signal`` argument in consumer (made optional in preparation for removal)
+
 [0.1.1] - 2023-05-12
 ************************************************
 

--- a/edx_event_bus_redis/__init__.py
+++ b/edx_event_bus_redis/__init__.py
@@ -5,6 +5,6 @@ Redis Streams implementation for the Open edX event bus.
 from edx_event_bus_redis.internal.consumer import RedisEventConsumer
 from edx_event_bus_redis.internal.producer import create_producer
 
-__version__ = '0.1.1'
+__version__ = '0.2.1'
 
 default_app_config = 'edx_event_bus_redis.apps.EdxEventBusRedisConfig'  # pylint: disable=invalid-name

--- a/edx_event_bus_redis/internal/message.py
+++ b/edx_event_bus_redis/internal/message.py
@@ -3,7 +3,7 @@ Redis message wrapper.
 """
 from typing import Dict, NamedTuple, Optional
 
-from openedx_events.tooling import EventsMetadata, OpenEdxPublicSignal
+from openedx_events.tooling import EventsMetadata
 
 from edx_event_bus_redis.internal.utils import get_headers_from_metadata, get_metadata_from_headers
 
@@ -35,14 +35,13 @@ class RedisMessage(NamedTuple):
         return data
 
     @classmethod
-    def parse(cls, msg: tuple, topic: str, expected_signal: Optional[OpenEdxPublicSignal] = None):
+    def parse(cls, msg: tuple, topic: str):
         """
         Takes message from redis stream and parses it to return an instance of RedisMessage.
 
         Args:
             msg: Tuple with 1st item being msg_id and 2nd data from message.
             topic: Stream name.
-            expected_signal [Optional]: If passed, the signal type is matched with type in msg.
 
         Returns:
             RedisMessage with msg_id
@@ -54,9 +53,4 @@ class RedisMessage(NamedTuple):
         except Exception as e:
             raise UnusableMessageError(f"Error determining metadata from message headers: {e}") from e
 
-        if expected_signal and metadata.event_type != expected_signal.event_type:
-            raise UnusableMessageError(
-                f"Signal types do not match. Expected {expected_signal.event_type}. "
-                f"Received message of type {metadata.event_type}."
-            )
         return cls(msg_id=msg_id, event_data=event_data_bytes, event_metadata=metadata, topic=topic)

--- a/edx_event_bus_redis/internal/tests/test_consumer.py
+++ b/edx_event_bus_redis/internal/tests/test_consumer.py
@@ -80,7 +80,6 @@ class TestConsumer(TestCase):
             self.event_consumer = RedisEventConsumer(
                 'local-some-topic',
                 'test_group_id',
-                self.signal,
                 consumer_name='test_group_id.c1',
                 check_backlog=True,
                 claim_msgs_older_than=10,
@@ -125,7 +124,6 @@ class TestConsumer(TestCase):
             RedisEventConsumer(
                 'local-some-topic',
                 'test_group_id',
-                self.signal,
                 consumer_name='test_group_id.c1',
                 last_read_msg_id=last_read_msg_id,
                 check_backlog=check_backlog,
@@ -200,8 +198,6 @@ class TestConsumer(TestCase):
         assert "Error consuming event from Redis: ValueError('something broke') in context" in exc_log_msg
         assert "full_topic='local-some-topic'" in exc_log_msg
         assert "consumer_group='test_group_id'" in exc_log_msg
-        assert ("expected_signal=<OpenEdxPublicSignal: "
-                "org.openedx.learning.auth.session.login.completed.v1>") in exc_log_msg
         assert "-- event details: " in exc_log_msg
         assert str(self.normal_message) in exc_log_msg
 
@@ -385,8 +381,6 @@ class TestConsumer(TestCase):
         assert f"Error consuming event from Redis: {repr(exception)} in context" in exc_log_msg
         assert "full_topic='local-some-topic'" in exc_log_msg
         assert "consumer_group='test_group_id'" in exc_log_msg
-        assert ("expected_signal=<OpenEdxPublicSignal: "
-                "org.openedx.learning.auth.session.login.completed.v1>") in exc_log_msg
         assert "-- no event available" in exc_log_msg
 
         expected_custom_attribute_calls = [
@@ -473,7 +467,7 @@ class TestConsumer(TestCase):
                 (lambda x:x, Exception("for lambda")),
                 # This would actually raise an error inside send_robust(), but it will serve well enough for testing...
                 ("not even a function", ValueError("just plain bad")),
-            ])
+            ], self.signal)
         assert exc_info.value.args == (
             "2 receiver(s) out of 2 produced errors (stack trace elsewhere in logs) "
             "when handling signal <OpenEdxPublicSignal: "

--- a/edx_event_bus_redis/internal/tests/test_message.py
+++ b/edx_event_bus_redis/internal/tests/test_message.py
@@ -77,24 +77,6 @@ class TestMessage(TestCase):
             "__init__() missing 1 required positional argument: 'event_type'",
         )
 
-    def test_unexpected_signal_type_in_msg(self):
-        msg = (
-            b'1',
-            {
-                b'id': b'629f9892-c258-11ed-8dac-1c83413013cb',
-                b'event_data': self.event_data_bytes,
-                b'type': b'incorrect-type',
-            }
-        )
-
-        with pytest.raises(UnusableMessageError) as excinfo:
-            RedisMessage.parse(msg, topic='some-local-topic', expected_signal=self.signal)
-
-        assert excinfo.value.args == (
-            "Signal types do not match. Expected org.openedx.learning.auth.session.login.completed.v1. "
-            "Received message of type incorrect-type.",
-        )
-
     def test_bad_msg(self):
         """
         Check that if we cannot process the message headers, we raise an UnusableMessageError
@@ -111,7 +93,7 @@ class TestMessage(TestCase):
         )
 
         with pytest.raises(UnusableMessageError) as excinfo:
-            RedisMessage.parse(msg, topic='some-local-topic', expected_signal=self.signal)
+            RedisMessage.parse(msg, topic='some-local-topic')
 
         assert excinfo.value.args == (
             "Error determining metadata from message headers: badly formed hexadecimal UUID string",


### PR DESCRIPTION
**Description:**
Make the 'signal' argument to the consumer optional in preparation for deprecation. Remove checking against the passed signal since more than one signal type may come from the same topic. See https://openedx-events.readthedocs.io/en/latest/decisions/0010-multiple-event-types-per-topic.html.

**GH:** https://github.com/openedx/openedx-events/issues/218

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.