### PR TITLE
fix: mark signals as already emitted by event bus

### DIFF
--- a/edx_event_bus_redis/internal/consumer.py
+++ b/edx_event_bus_redis/internal/consumer.py
@@ -282,7 +282,7 @@ class RedisEventConsumer(EventBusConsumer):
 
         signal = OpenEdxPublicSignal.get_signal_by_type(msg.event_metadata.event_type)
         event_data = deserialize_bytes_to_event_data(msg.event_data, signal)
-        send_results = signal.send_event_with_custom_metadata(msg.event_metadata, **event_data)
+        send_results = signal.send_event_with_custom_metadata(msg.event_metadata, **event_data, from_event_bus=True)
         # Raise an exception if any receivers errored out. This allows logging of the receivers
         # along with partition, offset, etc. in record_event_consuming_error. Hopefully the
         # receiver code is idempotent and we can just replay any messages that were involved.


### PR DESCRIPTION
**Description:** This PR mark the signals emitted from the event bus as emitted.

See https://github.com/openedx/openedx-events/pull/312 for more information

**JIRA:** Link to JIRA ticket

**Dependencies:** https://github.com/openedx/openedx-events/pull/312

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
