### PR TITLE
chore: Update repo to Python 3.9-3.12, Django 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ['3.8']
-        toxenv: [quality, docs, pii_check, django32, django40]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        toxenv: [quality, docs, pii_check, django42]
 
     steps:
     - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
+      if: matrix.python-version == '3.12' && matrix.toxenv == 'django42'
       uses: codecov/codecov-action@v3
       with:
         flags: unittests

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,6 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.8
+  version: 3.12
   install:
     - requirements: requirements/doc.txt

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ One Time Setup
   cd event-bus-redis
 
   # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
-  mkvirtualenv -p python3.8 event-bus-redis
+  mkvirtualenv -p python3.12 event-bus-redis
 
 
 Every time you develop something in this repo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -490,8 +490,8 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.8', None),
-    'django': ('https://docs.djangoproject.com/en/3.2/', 'https://docs.djangoproject.com/en/3.2/_objects/'),
+    'python': ('https://docs.python.org/3.12', None),
+    'django': ('https://docs.djangoproject.com/en/4.2/', 'https://docs.djangoproject.com/en/4.2/_objects/'),
     'model_utils': ('https://django-model-utils.readthedocs.io/en/latest/', None),
 }
 

--- a/edx_event_bus_redis/internal/tests/test_message.py
+++ b/edx_event_bus_redis/internal/tests/test_message.py
@@ -72,9 +72,17 @@ class TestMessage(TestCase):
         with pytest.raises(UnusableMessageError) as excinfo:
             RedisMessage.parse(msg, topic='some-local-topic')
 
-        assert excinfo.value.args == (
-            "Error determining metadata from message headers: "
-            "__init__() missing 1 required positional argument: 'event_type'",
+        assert excinfo.value.args in (
+            # Error in Python <=3.9, can be removed when we drop support for those
+            (
+                "Error determining metadata from message headers: "
+                "__init__() missing 1 required positional argument: 'event_type'",
+            ),
+            # Error in Python 3.10 and above
+            (
+                "Error determining metadata from message headers: "
+                "EventsMetadata.__init__() missing 1 required positional argument: 'event_type'",
+            ),
         )
 
     def test_bad_msg(self):

--- a/setup.py
+++ b/setup.py
@@ -160,5 +160,9 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32,40}
+envlist = py{38,39,310,311,312}-django{42}
 
 [pycodestyle]
 exclude = .git,.tox,migrations
@@ -32,8 +32,7 @@ norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =
-    django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
+    django42: Django>=4.2,<4.3
     -r{toxinidir}/requirements/test.txt
 commands =
     python manage.py check


### PR DESCRIPTION
**Description:** Upgrades the advertised and tested versions of Python to 3.9-3.12 and Django to 4.2, which is what is currently supported in edx-platform.

Closes #79 