### PR TITLE
Add timeouts to _read_pending_msgs

### DIFF
--- a/edx_event_bus_redis/__init__.py
+++ b/edx_event_bus_redis/__init__.py
@@ -5,6 +5,6 @@ Redis Streams implementation for the Open edX event bus.
 from edx_event_bus_redis.internal.consumer import RedisEventConsumer
 from edx_event_bus_redis.internal.producer import create_producer
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 default_app_config = 'edx_event_bus_redis.apps.EdxEventBusRedisConfig'  # pylint: disable=invalid-name

--- a/edx_event_bus_redis/internal/tests/test_utils.py
+++ b/edx_event_bus_redis/internal/tests/test_utils.py
@@ -1,6 +1,7 @@
 """
 Test header conversion utils
 """
+import time
 from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 from uuid import uuid1
@@ -16,6 +17,7 @@ from edx_event_bus_redis.internal.utils import (
     HEADER_ID,
     HEADER_SOURCELIB,
     HEADER_TIME,
+    Timeout,
     encode,
     get_headers_from_metadata,
     get_metadata_from_headers,
@@ -139,3 +141,16 @@ class TestUtils(TestCase):
             expected_metadata = EventsMetadata(event_type="abc", id=TEST_UUID)
             generated_metadata = get_metadata_from_headers(headers)
             self.assertDictEqual(attr.asdict(generated_metadata), attr.asdict(expected_metadata))
+
+
+class TestTimeout(TestCase):
+    """
+    Test the timeout context manager
+    """
+    def test_timeout(self):
+        """
+        Test that the timeout decorator raises a TimeoutError if the function takes too long
+        """
+        with pytest.raises(TimeoutError):
+            with Timeout(1):
+                time.sleep(2)


### PR DESCRIPTION
These redis methods don't timeout and can cause infinite hangs when redis goes down while reading the pending messages. We wrap them in our own timeouts now and make those trigger consumer restarts to force reconnects and prevent the hangs.
